### PR TITLE
Fix trash can getting covered with stickers

### DIFF
--- a/Classes/Editor/MovableViews/MovableViewCanvas.swift
+++ b/Classes/Editor/MovableViews/MovableViewCanvas.swift
@@ -93,6 +93,7 @@ final class MovableViewCanvas: IgnoreTouchesView, UIGestureRecognizerDelegate, M
     /// Sets up the trash bin used during deletion
     private func setUpTrashView() {
         trashView.accessibilityIdentifier = "Editor Movable View Canvas Trash View"
+        trashView.layer.zPosition = 1
         trashView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(trashView)
         


### PR DESCRIPTION
Fixes an issue where trash can is covered with the stickers. You can see the problematic screen capture [here](https://drive.google.com/file/d/1rc6fKEbC6FlisqTa8WViDwQHsMsXEThg/view?usp=sharing).

## How to test?

Prerequisites:

Checkout this branch
cd to `KanvasCameraExample`
run `bundle install` then `bundle exec pod install`

- Run the example app
- Tap start
- Add an image
- Add some stickers at the bottom area
- Tap and hold a sticker to prompt the “Trash Can” icon to appear
- Observe that Trash Can is visible

![Jan-19-2021 18-17-55](https://user-images.githubusercontent.com/5032900/105057787-9fea9300-5a86-11eb-9db2-31fc9c2335b6.gif)
