### PR TITLE
Adds a media picker type

### DIFF
--- a/.circleci/cache-version
+++ b/.circleci/cache-version
@@ -1,2 +1,2 @@
 # To invalidate the cache, generate a new UUID using `uuidgen` on the command line then paste it here
-4209E547-AA59-4F90-A5A0-2092607A84AD
+692D9EA3-46C9-4AE7-AEDB-4EA8DB24DC25

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -176,69 +176,31 @@ public class CameraController: UIViewController, MediaClipsEditorDelegate, Camer
     private var currentMode: CameraMode
     private var isRecording: Bool
     private var disposables: [NSKeyValueObservation] = []
-    private var recorderClass: CameraRecordingProtocol.Type
-    private var segmentsHandlerClass: SegmentsHandlerType.Type
     private let stickerProvider: StickerProvider?
     private let cameraZoomHandler: CameraZoomHandler
     private let feedbackGenerator: UINotificationFeedbackGenerator
-    private let captureDeviceAuthorizer: CaptureDeviceAuthorizing
     private let quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?
     private let tagCollection: UIView?
 
     private let mediaPicker: MediaPicker.Type
+    private let recorderClass: CameraRecordingProtocol.Type = CameraRecorder.self
+    private let segmentsHandlerClass: SegmentsHandlerType.Type = CameraSegmentHandler.self
+    private let captureDeviceAuthorizer: CaptureDeviceAuthorizing = CaptureDeviceAuthorizer()
 
     private weak var mediaPlayerController: MediaPlayerController?
-
-    /// Constructs a CameraController that will record from the device camera
-    /// and export the result to the device, saving to the phone all in between information
-    /// needed to attain the final output.
-    ///
-    /// - Parameters
-    ///   - settings: Settings to configure in which ways should the controller
-    /// interact with the user, which options should the controller give the user
-    /// and which should be the result of the interaction.
-    ///   - stickerProvider: Class that will provide the stickers in the editor.
-    ///   - analyticsProvider: An class conforming to KanvasCameraAnalyticsProvider
-    public init(settings: CameraSettings,
-                mediaPicker: MediaPicker.Type?,
-                stickerProvider: StickerProvider?,
-                analyticsProvider: KanvasAnalyticsProvider?,
-                quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
-                tagCollection: UIView?) {
-        self.settings = settings
-        currentMode = settings.initialMode
-        isRecording = false
-        self.mediaPicker = mediaPicker ?? KanvasMediaPickerViewController.self
-        self.recorderClass = CameraRecorder.self
-        self.segmentsHandlerClass = CameraSegmentHandler.self
-        self.captureDeviceAuthorizer = CaptureDeviceAuthorizer()
-        self.stickerProvider = stickerProvider
-        self.analyticsProvider = analyticsProvider
-        self.quickBlogSelectorCoordinator = quickBlogSelectorCoordinator
-        self.tagCollection = tagCollection
-        cameraZoomHandler = CameraZoomHandler(analyticsProvider: analyticsProvider)
-        feedbackGenerator = UINotificationFeedbackGenerator()
-        super.init(nibName: .none, bundle: .none)
-        cameraZoomHandler.delegate = self
-    }
 
     /// Constructs a CameraController that will take care of creating media
     /// as the result of user interaction.
     ///
     /// - Parameters:
-    ///   - settings: Settings to configure in which ways should the controller
-    /// interact with the user, which options should the controller give the user
-    /// and which should be the result of the interaction.
-    ///   - recorderClass: Class that will provide a recorder that defines how to record media.
-    ///   - segmentsHandlerClass: Class that will provide a segments handler for storing stop
-    /// motion segments and constructing final input.
-    ///   - captureDeviceAuthorizer: Class responsible for authorizing access to capture devices.
-    ///   - stickerProvider: Class that will provide the stickers in the editor.
-    ///   - analyticsProvider: A class conforming to KanvasCameraAnalyticsProvider
-    private init(settings: CameraSettings,
-         recorderClass: CameraRecordingProtocol.Type,
-         segmentsHandlerClass: SegmentsHandlerType.Type,
-         captureDeviceAuthorizer: CaptureDeviceAuthorizing,
+    ///   - settings: Settings to configure in which ways should the controller interact with the user, which options should the controller give the user and which should be the result of the interaction.
+    ///   - mediaPicker: A class providing a Media Picker UI conforming to `MediaPicker`.
+    ///   - stickerProvider: An object that will provide the stickers in the editor.
+    ///   - analyticsProvider: An object conforming to KanvasCameraAnalyticsProvider used by tracking methods.
+    ///   - quickBlogSelectorCoordinator: An object which handles the Quick Blog selection UI.
+    ///   - tagCollection: A view to be shown when selecting tags.
+    public init(settings: CameraSettings,
+            mediaPicker: MediaPicker.Type?,
          stickerProvider: StickerProvider?,
          analyticsProvider: KanvasAnalyticsProvider?,
          quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
@@ -246,10 +208,7 @@ public class CameraController: UIViewController, MediaClipsEditorDelegate, Camer
         self.settings = settings
         currentMode = settings.initialMode
         isRecording = false
-        self.mediaPicker = KanvasMediaPickerViewController.self
-        self.recorderClass = recorderClass
-        self.segmentsHandlerClass = segmentsHandlerClass
-        self.captureDeviceAuthorizer = captureDeviceAuthorizer
+        self.mediaPicker = mediaPicker ?? KanvasMediaPickerViewController.self
         self.stickerProvider = stickerProvider
         self.analyticsProvider = analyticsProvider
         self.quickBlogSelectorCoordinator = quickBlogSelectorCoordinator

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -183,9 +183,9 @@ public class CameraController: UIViewController, MediaClipsEditorDelegate, Camer
     private let tagCollection: UIView?
 
     private let mediaPicker: MediaPicker.Type
-    private let recorderClass: CameraRecordingProtocol.Type = CameraRecorder.self
-    private let segmentsHandlerClass: SegmentsHandlerType.Type = CameraSegmentHandler.self
-    private let captureDeviceAuthorizer: CaptureDeviceAuthorizing = CaptureDeviceAuthorizer()
+    var recorderClass: CameraRecordingProtocol.Type = CameraRecorder.self
+    var segmentsHandlerClass: SegmentsHandlerType.Type = CameraSegmentHandler.self
+    var captureDeviceAuthorizer: CaptureDeviceAuthorizing = CaptureDeviceAuthorizer()
 
     private weak var mediaPlayerController: MediaPlayerController?
 

--- a/Classes/MediaPicker/MediaPicker.swift
+++ b/Classes/MediaPicker/MediaPicker.swift
@@ -1,0 +1,10 @@
+/// A type which displays a media picker and calls the `delegate` with any received media.
+public protocol MediaPicker {
+    /// Presents the Media Picker UI
+    /// - Parameters:
+    ///   - on: The view controller to present on.
+    ///   - settings: The `CameraSettings` which Kanvas has been started with.
+    ///   - delegate: A delegate which will receive the media.
+    ///   - completion: The completion to call upon presentation.
+    static func present(on: UIViewController, with settings: CameraSettings, delegate: KanvasMediaPickerViewControllerDelegate, completion: @escaping () -> Void)
+}

--- a/Classes/MediaPicker/MediaPickerViewController.swift
+++ b/Classes/MediaPicker/MediaPickerViewController.swift
@@ -9,11 +9,11 @@ import UIKit
 import MobileCoreServices
 import Photos
 
-protocol KanvasMediaPickerViewControllerDelegate: class {
-    func didPick(image: UIImage, url: URL?)
-    func didPick(video: URL)
-    func didPick(gif: URL)
-    func didPick(livePhotoStill: UIImage, pairedVideo: URL)
+public protocol KanvasMediaPickerViewControllerDelegate: class {
+    func didPick(images: [(UIImage, URL?)])
+    func didPick(videos: [URL])
+    func didPick(gifs: [URL])
+    func didPick(livePhotos: [(UIImage, URL)])
     func didCancel()
     func pickingMediaNotAllowed(reason: String)
 }
@@ -28,7 +28,7 @@ final class KanvasUIImagePickerController: UIImagePickerController {
     }
 }
 
-final class KanvasMediaPickerViewController: UIViewController {
+final class KanvasMediaPickerViewController: UIViewController, MediaPicker {
 
     let settings: CameraSettings
 
@@ -56,6 +56,12 @@ final class KanvasMediaPickerViewController: UIViewController {
         super.viewDidLoad()
         addChild(imagePickerController)
         view.addSubview(imagePickerController.view)
+    }
+
+    static func present(on: UIViewController, with settings: CameraSettings, delegate: KanvasMediaPickerViewControllerDelegate, completion: @escaping () -> Void) {
+        let picker = KanvasMediaPickerViewController(settings: settings)
+        picker.delegate = delegate
+        on.present(picker, animated: true, completion: completion)
     }
 }
 
@@ -144,7 +150,7 @@ private extension KanvasMediaPickerViewController {
                 cannotPick(reason: message)
                 return
             }
-            pick(image: image, url: mediaURL)
+            pick(image: image, url: imageURL)
         }
         else if let mediaURL = mediaURL {
             pick(video: mediaURL)
@@ -155,19 +161,19 @@ private extension KanvasMediaPickerViewController {
     }
 
     private func pick(frames imageURL: URL) {
-        delegate?.didPick(gif: imageURL)
+        delegate?.didPick(gifs: [imageURL])
     }
 
     private func pick(image: UIImage, url: URL?) {
-        delegate?.didPick(image: image, url: url)
+        delegate?.didPick(images: [(image: image, url: url)])
     }
 
     private func pick(video url: URL) {
-        delegate?.didPick(video: url)
+        delegate?.didPick(videos: [url])
     }
 
     private func pick(livePhotoStill: UIImage, pairedVideo: URL) {
-        delegate?.didPick(livePhotoStill: livePhotoStill, pairedVideo: pairedVideo)
+        delegate?.didPick(livePhotos: [(still: livePhotoStill, pairedVideo: pairedVideo)])
     }
 
     private func canPick(image: UIImage) -> Bool {

--- a/KanvasExample/KanvasExample/ExampleKanvasDashboardController.swift
+++ b/KanvasExample/KanvasExample/ExampleKanvasDashboardController.swift
@@ -264,7 +264,7 @@ private extension KanvasDashboardController {
     func createCameraController() -> CameraController {
         let kanvasAnalyticsProvider = stateDelegate?.kanvasDashboardAnalyticsProvider
         let stickerProvider = ExperimentalStickerProvider()
-        let kanvasViewController = CameraController(settings: settings, stickerProvider: stickerProvider, analyticsProvider: kanvasAnalyticsProvider, quickBlogSelectorCoordinator: nil, tagCollection: nil)
+        let kanvasViewController = CameraController(settings: settings, mediaPicker: nil, stickerProvider: stickerProvider, analyticsProvider: kanvasAnalyticsProvider, quickBlogSelectorCoordinator: nil, tagCollection: nil)
         kanvasViewController.delegate = self
         return kanvasViewController
     }

--- a/KanvasExample/KanvasExample/KanvasExampleViewController.swift
+++ b/KanvasExample/KanvasExample/KanvasExampleViewController.swift
@@ -160,7 +160,7 @@ final class KanvasExampleViewController: UIViewController {
     }
 
     private func launchCamera(animated: Bool = true) {
-        let controller = CameraController(settings: cameraSettings, stickerProvider: ExperimentalStickerProvider(), analyticsProvider: KanvasAnalyticsStub(), quickBlogSelectorCoordinator: nil, tagCollection: nil)
+        let controller = CameraController(settings: cameraSettings, mediaPicker: nil, stickerProvider: ExperimentalStickerProvider(), analyticsProvider: KanvasAnalyticsStub(), quickBlogSelectorCoordinator: nil, tagCollection: nil)
         controller.delegate = self
         controller.modalPresentationStyle = .fullScreen
         controller.modalTransitionStyle = .crossDissolve

--- a/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
@@ -39,7 +39,15 @@ final class CameraControllerTests: FBSnapshotTestCase {
     }
 
     func newController(delegate: CameraControllerDelegate, settings: CameraSettings) -> CameraController {
-        let controller = CameraController(settings: settings, recorderClass: CameraRecorderStub.self, segmentsHandlerClass: CameraSegmentHandlerStub.self, captureDeviceAuthorizer: MockCaptureDeviceAuthorizer(initialCameraAccess: .authorized, initialMicrophoneAccess: .authorized, requestedCameraAccessAnswer: .authorized, requestedMicrophoneAccessAnswer: .authorized), stickerProvider: StickerProviderStub(), analyticsProvider: KanvasAnalyticsStub(), quickBlogSelectorCoordinator: nil, tagCollection: nil)
+        let controller = CameraController(settings: settings,
+                                          mediaPicker: nil,
+                                          stickerProvider: StickerProviderStub(),
+                                          analyticsProvider: KanvasAnalyticsStub(),
+                                          quickBlogSelectorCoordinator: nil,
+                                          tagCollection: nil)
+        controller.recorderClass = CameraRecorderStub.self
+        controller.segmentsHandlerClass = CameraSegmentHandlerStub.self
+        controller.captureDeviceAuthorizer = MockCaptureDeviceAuthorizer(initialCameraAccess: .authorized, initialMicrophoneAccess: .authorized, requestedCameraAccessAnswer: .authorized, requestedMicrophoneAccessAnswer: .authorized)
         controller.delegate = delegate
         controller.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
         UIView.setAnimationsEnabled(false)


### PR DESCRIPTION
The media picker will be implemented by the calling application so that it can choose to display its own interface (e.g. [WPMediaPicker](https://github.com/wordpress-mobile/MediaPicker-iOS) for WordPress iOS).

For now, the `KanvasMediaPickerViewController` remains as a default bridge to the system photo picker.

## Code
- `MediaPicker.swift` contains the new protocol type which just has a method to present the UI with corresponding settings and delegate object.
- The initializer in `CameraController` has been cleaned up a bit so that we don't have two of them. The properties with default internal types are now declared as initial values at the property site.

## Testing

- Open the example app.
- Ensure that the Media Picker still functions as expected.