### PR TITLE
Add Permissions Button color customization

### DIFF
--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -56,8 +56,8 @@ class CameraPermissionsView: UIView, CameraPermissionsViewable, MediaPickerButto
         static let descriptionFont: UIFont = KanvasFonts.shared.permissions.descriptionFont
         static let descriptionOpacity: CGFloat = 0.65
         static let buttonFont: UIFont = KanvasFonts.shared.permissions.buttonFont
-        static let buttonColor: UIColor = .init(red: 0, green: 184.0/255.0, blue: 1.0, alpha: 1.0)
-        static let buttonAcceptedBackgroundColor: UIColor = .init(hex: 0x00cf35)
+        static let buttonColor: UIColor = KanvasColors.shared.permissionsButtonColor
+        static let buttonAcceptedBackgroundColor: UIColor = KanvasColors.shared.permissionsButtonAcceptedBackgroundColor
         static let buttonAcceptedColor: UIColor = .black
         static let buttonBorderWidth: CGFloat = 1.5
     }

--- a/Classes/Constants/KanvasColors.swift
+++ b/Classes/Constants/KanvasColors.swift
@@ -75,6 +75,8 @@ public struct KanvasColors {
             tooltipBackgroundColor: .systemRed,
             closeButtonColor: black25,
             primaryButtonBackgroundColor: brightBlue,
+            permissionsButtonColor: UIColor(red: 0, green: 184.0/255.0, blue: 1.0, alpha: 1.0),
+            permissionsButtonAcceptedBackgroundColor: UIColor(hex: 0x00cf35),
             overlayColor: deepBlue,
             filterColors: [
                 .manga: brightPink,
@@ -109,6 +111,8 @@ public struct KanvasColors {
         tooltipBackgroundColor: UIColor,
         closeButtonColor: UIColor,
         primaryButtonBackgroundColor: UIColor,
+        permissionsButtonColor: UIColor,
+        permissionsButtonAcceptedBackgroundColor: UIColor,
         overlayColor: UIColor,
         filterColors: [FilterType: UIColor]) {
         self.drawingDefaultColor = drawingDefaultColor
@@ -124,9 +128,14 @@ public struct KanvasColors {
         self.tooltipBackgroundColor = tooltipBackgroundColor
         self.closeButtonColor = closeButtonColor
         self.primaryButtonBackgroundColor = primaryButtonBackgroundColor
+        self.permissionsButtonColor = permissionsButtonColor
+        self.permissionsButtonAcceptedBackgroundColor = permissionsButtonAcceptedBackgroundColor
         self.overlayColor = overlayColor
         self.filterColors = filterColors
     }
+
+    let permissionsButtonColor: UIColor
+    let permissionsButtonAcceptedBackgroundColor: UIColor
     
     let drawingDefaultColor: UIColor // DrawingController:50
     let colorPickerColors: [UIColor] // ColorPickerView:37

--- a/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
+++ b/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1625,14 +1625,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Q5R9EF4JAK;
+				DEVELOPMENT_TEAM = 84Q69XA6W4;
 				INFOPLIST_FILE = KanvasExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.titus.KanvasExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tumblr.KanvasExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/KanvasExample/KanvasExample/KanvasCustomUI.swift
+++ b/KanvasExample/KanvasExample/KanvasCustomUI.swift
@@ -76,6 +76,8 @@ public class KanvasCustomUI {
             tooltipBackgroundColor: .systemRed,
             closeButtonColor: black25,
             primaryButtonBackgroundColor: Self.brightBlue,
+            permissionsButtonColor: UIColor(red: 0, green: 184.0/255.0, blue: 1.0, alpha: 1.0),
+            permissionsButtonAcceptedBackgroundColor: UIColor(hex: 0x00cf35),
             overlayColor: Self.deepBlue,
             filterColors: [
                 .manga: mangaColor,


### PR DESCRIPTION
Adds permissions button colors properties to `KanvasColors`:

* `KanvasColors.permissionsButtonColor`
* `KanvasColors.permissionsButtonAcceptedBackgroundColor`

We want to customize these colors a bit for WordPress iOS: https://github.com/tumblr/kanvas-ios/issues/54