### PR TITLE
Add `scaleMediaToFill` setting enabling media scaling

### DIFF
--- a/Classes/Camera/FilteredInputViewController.swift
+++ b/Classes/Camera/FilteredInputViewController.swift
@@ -65,12 +65,12 @@ final class FilteredInputViewController: UIViewController, RendererDelegate {
     // MARK: - layout
     private func setupPreview() {
         if settings.features.openGLPreview {
-            let previewView = GLPixelBufferView(delegate: nil, mediaContentMode: .scaleAspectFit)
+            let previewView = GLPixelBufferView(delegate: nil, mediaContentMode: settings.features.scaleMediaToFill ? .scaleAspectFill : .scaleAspectFit)
             previewView.add(into: view)
             self.previewView = previewView
         }
         else {
-            let previewView = MetalPixelBufferView(context: metalContext)
+            let previewView = MetalPixelBufferView(context: metalContext, mediaContentMode: settings.features.scaleMediaToFill ? .scaleAspectFill : .scaleAspectFit)
             previewView.add(into: view)
             self.previewView = previewView
         }

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -202,12 +202,13 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     }()
     
     weak var delegate: EditorViewDelegate?
+    private var mediaContentMode: UIView.ContentMode
     
     @available(*, unavailable, message: "use init() instead")
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     init(delegate: EditorViewDelegate?,
          mainActionMode: MainActionMode,
          showSaveButton: Bool,
@@ -219,7 +220,8 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
          showBlogSwitcher: Bool,
          quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
          tagCollection: UIView?,
-         metalContext: MetalContext?) {
+         metalContext: MetalContext?,
+         mediaContentMode: UIView.ContentMode) {
         self.delegate = delegate
         self.mainActionMode = mainActionMode
         self.showSaveButton = showSaveButton
@@ -232,6 +234,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         self.quickBlogSelectorCoordinator = quickBlogSelectorCoordinator
         self.tagCollection = tagCollection
         self.metalContext = metalContext
+        self.mediaContentMode = mediaContentMode
         super.init(frame: .zero)
         setupViews()
     }
@@ -281,7 +284,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     // MARK: - views
 
     private func setupPlayer() {
-        let playerView = MediaPlayerView(metalContext: metalContext)
+        let playerView = MediaPlayerView(metalContext: metalContext, mediaContentMode: mediaContentMode)
         playerView.delegate = self
         playerView.add(into: self)
         self.playerView = playerView

--- a/Classes/Rendering/MediaPlayer.swift
+++ b/Classes/Rendering/MediaPlayer.swift
@@ -67,15 +67,15 @@ final class MediaPlayerView: UIView, GLPixelBufferViewDelegate {
 
     weak var delegate: MediaPlayerViewDelegate?
 
-    init(metalContext: MetalContext?) {
+    init(metalContext: MetalContext?, mediaContentMode: UIView.ContentMode) {
         super.init(frame: .zero)
 
         let pixelBufferView: PixelBufferView & UIView
         if let metalContext = metalContext {
-            pixelBufferView = MetalPixelBufferView(context: metalContext)
+            pixelBufferView = MetalPixelBufferView(context: metalContext, mediaContentMode: mediaContentMode)
         }
         else {
-            pixelBufferView = GLPixelBufferView(delegate: self, mediaContentMode: .scaleAspectFit)
+            pixelBufferView = GLPixelBufferView(delegate: self, mediaContentMode: mediaContentMode)
         }
 
         pixelBufferView.add(into: self)
@@ -519,7 +519,14 @@ final class MediaPlayer {
             return
         }
         if let sampleBuffer = output?.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil)?.sampleBuffer() {
-            renderer.processSampleBuffer(sampleBuffer, time: Date.timeIntervalSinceReferenceDate - startTime)
+            let size: CGSize?
+            
+            if let playerView = playerView, playerView.pixelBufferView?.mediaContentMode == .scaleAspectFill {
+                size = CGSize(width: playerView.frame.width * playerView.contentScaleFactor, height: playerView.frame.height * playerView.contentScaleFactor)
+            } else {
+                size = nil
+            }
+            renderer.processSampleBuffer(sampleBuffer, time: Date.timeIntervalSinceReferenceDate - startTime, scaleToFillSize: size)
         }
     }
 

--- a/Classes/Rendering/OpenGL/GLPixelBufferView.swift
+++ b/Classes/Rendering/OpenGL/GLPixelBufferView.swift
@@ -43,7 +43,7 @@ final class GLPixelBufferView: UIView, PixelBufferView {
         }
     }
 
-    private var mediaContentMode: UIView.ContentMode = .scaleAspectFill {
+    private(set) var mediaContentMode: UIView.ContentMode = .scaleAspectFill {
         didSet {
             guard mediaContentMode == .scaleAspectFill || mediaContentMode == .scaleAspectFit else {
                 assertionFailure("GLPixelBufferView.mediaContentMode only supports scaleAspectFill and scaleAspectFit")

--- a/Classes/Rendering/PixelBufferView.swift
+++ b/Classes/Rendering/PixelBufferView.swift
@@ -9,6 +9,7 @@ import GLKit
 
 protocol PixelBufferView: class {
     var mediaTransform: GLKMatrix4? { get set }
+    var mediaContentMode: UIView.ContentMode { get }
     var isPortrait: Bool { get set }
     func displayPixelBuffer(_ pixelBuffer: CVPixelBuffer)
     func flushPixelBufferCache()

--- a/Classes/Rendering/VideoCompositor.swift
+++ b/Classes/Rendering/VideoCompositor.swift
@@ -73,8 +73,6 @@ final class VideoCompositor: NSObject, AVVideoCompositing {
 
     var startTime: CMTime?
 
-    var dimensions: CGSize = .zero
-
     /// Convenience initializer
     override convenience init() {
         self.init(
@@ -99,7 +97,7 @@ final class VideoCompositor: NSObject, AVVideoCompositing {
     }
 
     func startRequest(_ asyncVideoCompositionRequest: AVAsynchronousVideoCompositionRequest) {
-        renderingQueue.async {
+        renderingQueue.async { [self] in
             if self.shouldCancelAllRequests {
                 asyncVideoCompositionRequest.finishCancelledRequest()
             }
@@ -126,10 +124,10 @@ final class VideoCompositor: NSObject, AVVideoCompositing {
 
                 if self.firstFrame {
                     self.startTime = asyncVideoCompositionRequest.compositionTime
-                    self.renderer.processSampleBuffer(sampleBuffer, time: 0)
+                    self.renderer.processSampleBuffer(sampleBuffer, time: 0, scaleToFillSize: asyncVideoCompositionRequest.renderContext.size)
                     self.firstFrame = false
                 }
-                self.renderer.processSampleBuffer(sampleBuffer, time: asyncVideoCompositionRequest.compositionTime.seconds - (self.startTime?.seconds ?? 0))
+                self.renderer.processSampleBuffer(sampleBuffer, time: asyncVideoCompositionRequest.compositionTime.seconds - (self.startTime?.seconds ?? 0), scaleToFillSize: asyncVideoCompositionRequest.renderContext.size)
             }
         }
     }

--- a/Classes/Settings/CameraSettings.swift
+++ b/Classes/Settings/CameraSettings.swift
@@ -159,6 +159,11 @@ public struct CameraFeatures {
     /// Multi-Export support
     /// This enables multiple images/videos to be taken, edited, and then exported
     public var multipleExports = false
+
+    /// Scale media to fill
+    /// This scales the imported media to fill the screen by setting the `mediaContentMode` to `scaleAspectFill` on the pixel buffer views.
+    /// The buffer views will resize their contents during drawing to fill the screen.
+    public var scaleMediaToFill: Bool = false
 }
 
 // A class that defines the settings for the Kanvas Camera

--- a/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
+++ b/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1625,14 +1625,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 84Q69XA6W4;
+				DEVELOPMENT_TEAM = Q5R9EF4JAK;
 				INFOPLIST_FILE = KanvasExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.tumblr.KanvasExample;
+				PRODUCT_BUNDLE_IDENTIFIER = io.titus.KanvasExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/KanvasExample/KanvasExample/FeatureTableView.swift
+++ b/KanvasExample/KanvasExample/FeatureTableView.swift
@@ -41,6 +41,7 @@ class FeatureTableView: UIView, UITableViewDelegate, UITableViewDataSource, Feat
         case gifCameraShouldStartGIFMaker(Bool)
         case exportStopMotionAsVideo(Bool)
         case multipleExport(Bool)
+        case scaleMediaToFill(Bool)
 
         var name: String {
             switch self {
@@ -96,6 +97,8 @@ class FeatureTableView: UIView, UITableViewDelegate, UITableViewDataSource, Feat
                 return "Export Stop Motion as Video"
             case .multipleExport:
                 return "Multiple Exports"
+            case .scaleMediaToFill:
+                return "Scale Media to Fill"
             }
         }
 
@@ -152,6 +155,8 @@ class FeatureTableView: UIView, UITableViewDelegate, UITableViewDataSource, Feat
             case .exportStopMotionAsVideo(let enabled):
                 return enabled
             case .multipleExport(let enabled):
+                return enabled
+            case .scaleMediaToFill(let enabled):
                 return enabled
             }
         }
@@ -247,6 +252,8 @@ class FeatureTableView: UIView, UITableViewDelegate, UITableViewDataSource, Feat
             featuresData[indexPath.row] = .exportStopMotionAsVideo(value)
         case .multipleExport(_):
             featuresData[indexPath.row] = .multipleExport(value)
+        case .scaleMediaToFill(_):
+            featuresData[indexPath.row] = .scaleMediaToFill(value)
         }
         delegate?.featureTableView(didUpdateFeature: featuresData[indexPath.row], withValue: value)
     }

--- a/KanvasExample/KanvasExample/KanvasExampleViewController.swift
+++ b/KanvasExample/KanvasExample/KanvasExampleViewController.swift
@@ -148,6 +148,7 @@ final class KanvasExampleViewController: UIViewController {
         settings.gifCameraShouldStartGIFMaker = true
         settings.exportStopMotionPhotoAsVideo = true
         settings.features.multipleExports = false
+        settings.features.scaleMediaToFill = false
         return settings
     }
 
@@ -277,6 +278,7 @@ extension KanvasExampleViewController: FeatureTableViewDelegate {
             .gifCameraShouldStartGIFMaker(settings.gifCameraShouldStartGIFMaker),
             .exportStopMotionAsVideo(settings.exportStopMotionPhotoAsVideo),
             .multipleExport(settings.features.multipleExports),
+            .scaleMediaToFill(settings.features.scaleMediaToFill)
         ]
     }
 
@@ -336,6 +338,8 @@ extension KanvasExampleViewController: FeatureTableViewDelegate {
             settings.exportStopMotionPhotoAsVideo = value
         case .multipleExport(_):
             settings.features.multipleExports = value
+        case .scaleMediaToFill(_):
+            settings.features.scaleMediaToFill = value
         }
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
@@ -22,17 +22,17 @@ class MediaExporterStub: MediaExporting {
 
     }
 
-    func export(image: UIImage, time: TimeInterval, completion: (UIImage?, Error?) -> Void) {
+    func export(image: UIImage, time: TimeInterval, toSize: CGSize?, completion: (UIImage?, Error?) -> Void) {
         exportImageCalled = true
         completion(image, nil)
     }
 
-    func export(frames: [MediaFrame], completion: @escaping ([MediaFrame]) -> Void) {
+    func export(frames: [MediaFrame], toSize: CGSize?, completion: @escaping ([MediaFrame]) -> Void) {
         exportFramesCalled = true
         completion(frames)
     }
 
-    func export(video url: URL, mediaInfo: MediaInfo, completion: @escaping (URL?, Error?) -> Void) {
+    func export(video url: URL, mediaInfo: MediaInfo, toSize: CGSize?, completion: @escaping (URL?, Error?) -> Void) {
         exportVideoCalled = true
         completion(url, nil)
     }

--- a/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
@@ -32,7 +32,7 @@ final class EditorViewTests: FBSnapshotTestCase {
                               showBlogSwitcher: false,
                               quickBlogSelectorCoordinator: nil,
                               tagCollection: nil,
-                              metalContext: nil)
+                              metalContext: nil, mediaContentMode: .scaleAspectFit)
         view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
         return view
     }

--- a/KanvasExample/KanvasExampleTests/Rendering/MediaPlayerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Rendering/MediaPlayerViewTests.swift
@@ -28,7 +28,7 @@ class MediaPlayerViewTests: FBSnapshotTestCase {
             return
         }
         let player = MediaPlayer(renderer: Renderer())
-        let view = MediaPlayerView(metalContext: nil)
+        let view = MediaPlayerView(metalContext: nil, mediaContentMode: .scaleAspectFit)
         view.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
         player.playerView = view
         player.play(media: [.image(image, nil)])

--- a/KanvasExample/KanvasExampleTests/Rendering/Metal/MetalPixelBufferViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Rendering/Metal/MetalPixelBufferViewTests.swift
@@ -17,7 +17,7 @@ class MetalPixelBufferViewTests: FBSnapshotTestCase {
         guard let context = MetalContext.createContext() else {
             return
         }
-        let view = MetalPixelBufferView(context: context)
+        let view = MetalPixelBufferView(context: context, mediaContentMode: .scaleAspectFit)
         XCTAssertNotNil(view)
         
         let filter = MetalFilter(context: context, kernelFunctionName: "kernelIdentity")


### PR DESCRIPTION
A new `scaleMediaToFill` setting will enable the developer to toggle the `mediaContentMode` of the buffer views. Each buffer view should resize its contents to match this content mode setting.

This fills the screen with the media according to its aspect ratio and crops its sides as necessary.

## Testing
1. Enable the `Metal Filters`, `Camera Metal`, and `Scale Media to Fill` flags, disable the `Camera OpenGL` and `Camera OpenGL Capture` flags.
2. Take photos and video and import media from the photo library.
3. Ensure that media is properly displayed and exported with contents.

| Enabled | Disabled (before) |
| ------- | ----------------- |
| <a href="https://user-images.githubusercontent.com/3250/108017096-4d42bf00-6fd1-11eb-845e-a460ee09d6a8.PNG"><img src="https://user-images.githubusercontent.com/3250/108017096-4d42bf00-6fd1-11eb-845e-a460ee09d6a8.PNG" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/108017115-57fd5400-6fd1-11eb-951b-d46f03572bbe.PNG"><img src="https://user-images.githubusercontent.com/3250/108017115-57fd5400-6fd1-11eb-951b-d46f03572bbe.PNG" width="300"></a> |

