### PR TITLE
Fix filter getting reset after sending the app to background

### DIFF
--- a/Classes/Camera/Filters/CameraFilterCollectionController.swift
+++ b/Classes/Camera/Filters/CameraFilterCollectionController.swift
@@ -95,11 +95,11 @@ final class CameraFilterCollectionController: UIViewController, UICollectionView
         filterCollectionView.collectionView.delegate = self
         filterCollectionView.collectionView.dataSource = self
         setUpView()
+        scrollToOption(at: Constants.initialIndex, animated: false)
     }
     
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        scrollToOption(at: Constants.initialIndex, animated: false)
         filterCollectionView.collectionView.collectionViewLayout.invalidateLayout()
         filterCollectionView.collectionView.layoutIfNeeded()
         scrollHandler?.changeSize(IndexPath(item: Constants.initialIndex, section: Constants.section))


### PR DESCRIPTION
This PR fixes an issue where the selected filter is reset after sending the app to background and bringing back.

**To Test**

Checkout this branch
cd to KanvasCameraExample
run bundle exec pod install

Run the example app
Tap start
Change the camera filter via the rounded icon above the big record button
Send the app to background
Bring the app from background
Verify the selected filter is kept
