### PR TITLE
A few minor Bug Fixes

### DIFF
--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -72,7 +72,7 @@ class CameraPermissionsView: UIView, CameraPermissionsViewable, MediaPickerButto
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = NSLocalizedString("Post to Tumblr", comment: "Title of camera permissions screen")
+        label.text = KanvasStrings.shared.cameraPermissionsTitleLabel
         label.font = Constants.titleFont
         label.textColor = Constants.textColor
         label.textAlignment = .center
@@ -83,7 +83,7 @@ class CameraPermissionsView: UIView, CameraPermissionsViewable, MediaPickerButto
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
 
-        let description = NSLocalizedString("Allow access so you can start taking photos and videos", comment: "Message on camera permissions screen to explain why the Tumblr app needs camera and microphone permissions")
+        let description = KanvasStrings.shared.cameraPermissionsDescriptionLabel
         let descriptionParagraphStyle = NSMutableParagraphStyle()
         descriptionParagraphStyle.lineSpacing = Constants.descriptionFont.pointSize * 0.5
         let descriptionAttributedString = NSMutableAttributedString(string: description)
@@ -108,7 +108,7 @@ class CameraPermissionsView: UIView, CameraPermissionsViewable, MediaPickerButto
     }()
 
     private lazy var microphoneAccessButton: UIButton = {
-        let title = NSLocalizedString("Allow access to microphone", comment: "Button on camera permissions screen to initiate the sytem prompt for microphone access")
+        let title = NSLocalizedString("Allow access to microphone", comment: "Button on camera permissions screen to initiate the sytem prompt for microphone access.")
         let titleDisabled = NSLocalizedString("Microphone access granted", comment: "Label on camera permissions screen to indicate microphone access is granted")
         let button = CameraPermissionsView.makeButton(title: title, titleDisabled: titleDisabled)
         button.translatesAutoresizingMaskIntoConstraints = false

--- a/Classes/Constants/KanvasStrings.swift
+++ b/Classes/Constants/KanvasStrings.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 // the values for common string throughout the module
-struct KanvasStrings {
+public struct KanvasStrings {
     // MARK: - Camera Modes
 
     // photoModeName: used in the camera mode button
@@ -41,5 +41,19 @@ struct KanvasStrings {
 
     static func bundlePath(for aClass: AnyClass) -> String? {
         return Bundle(for: aClass).path(forResource: "Kanvas", ofType: "bundle")
+    }
+
+    public var cameraPermissionsTitleLabel: String
+    public var cameraPermissionsDescriptionLabel: String
+
+    public static var shared = KanvasStrings(
+        cameraPermissionsTitleLabel: NSLocalizedString("Post to Tumblr", comment: "Title of camera permissions screen"),
+        cameraPermissionsDescriptionLabel: NSLocalizedString("Allow access so you can start taking photos and videos", comment: "Message on camera permissions screen to explain why the Tumblr app needs camera and microphone permissions")
+    )
+
+    public init(cameraPermissionsTitleLabel: String,
+                cameraPermissionsDescriptionLabel: String) {
+        self.cameraPermissionsTitleLabel = cameraPermissionsTitleLabel
+        self.cameraPermissionsDescriptionLabel = cameraPermissionsDescriptionLabel
     }
 }

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -237,6 +237,18 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         self.movableViewCanvas.delegate = self
         setupViews()
     }
+
+    func updateUI(forDraggingClip: Bool) {
+        if forDraggingClip {
+            self.movableViewCanvas.showTrash()
+        } else {
+            self.movableViewCanvas.hideTrash()
+        }
+        UIView.animate(withDuration: 0.5, animations: {
+            self.collectionContainer.alpha = forDraggingClip ? 0.0 : 1.0
+            self.collectionContainer.isHidden = forDraggingClip
+        })
+    }
     
     private func setupViews() {
         setupPlayer()

--- a/Classes/Editor/MovableViews/MovableViewCanvas.swift
+++ b/Classes/Editor/MovableViews/MovableViewCanvas.swift
@@ -73,6 +73,15 @@ final class MovableViewCanvas: IgnoreTouchesView, UIGestureRecognizerDelegate, M
         return movableViews.isEmpty
     }
 
+    var trashCompletion: (() -> Void)? {
+        set {
+            trashView.completion = newValue
+        }
+        get {
+            return trashView.completion
+        }
+    }
+
     var movableViews: [MovableView] {
         return subviews.compactMap { $0 as? MovableView }
     }
@@ -223,6 +232,30 @@ final class MovableViewCanvas: IgnoreTouchesView, UIGestureRecognizerDelegate, M
     func removeSelectedView() {
         selectedMovableView?.removeFromSuperview()
         selectedMovableView = nil
+    }
+
+    /// shows the trash icon opened with its red background
+    func openTrash() {
+        trashView.open()
+    }
+
+    /// shows the trash icon closed
+    func showTrash() {
+        showOverlay(true)
+        trashView.superview?.bringSubviewToFront(trashView)
+        movableViews.forEach { movableView in
+            movableView.fadeOut()
+        }
+        trashView.close()
+    }
+
+    /// hides the trash icon with its red background
+    func hideTrash() {
+        showOverlay(false)
+        movableViews.forEach { movableView in
+            movableView.fadeIn()
+        }
+        trashView.hide()
     }
     
     // MARK: - Gesture recognizers

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -144,6 +144,9 @@ class MultiEditorViewController: UIViewController {
             }
             editor.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottom, right: 0)
             editor.delegate = self
+            editor.editorView.movableViewCanvas.trashCompletion = { [weak self] in
+                self?.clipsController.removeDraggingClip()
+            }
             load(childViewController: editor, into: editorContainer)
             currentEditor = editor
         }
@@ -197,11 +200,11 @@ extension MultiEditorViewController: MediaPlayerController {
 
 extension MultiEditorViewController: MediaClipsEditorDelegate {
     func mediaClipStartedMoving() {
-        // No-op for the moment. UI is coming in a future commit.
+        currentEditor?.editorView.updateUI(forDraggingClip: true)
     }
 
     func mediaClipFinishedMoving() {
-        // No-op for the moment. UI is coming in a future commit.
+        currentEditor?.editorView.updateUI(forDraggingClip: false)
     }
     
     func addButtonWasPressed() {

--- a/Classes/Editor/Text/EditorTextView.swift
+++ b/Classes/Editor/Text/EditorTextView.swift
@@ -309,8 +309,8 @@ final class EditorTextView: UIView, MainTextViewDelegate {
     }
 
     private func refreshFontSelector() {
-        if let attributedFont = font?.withSize(18) {
-            fontSelector.setAttributedTitle(NSAttributedString(string: "Aa", attributes: [.font: attributedFont]), for: .normal)
+        if let attributedFont = font?.withSize(20) {
+            fontSelector.setAttributedTitle(NSAttributedString(string: "Aa", attributes: [.font: attributedFont, .foregroundColor: UIColor.white]), for: .normal)
         }
     }
     

--- a/Classes/Utility/IgnoreTouches/IgnoreTouchesView.swift
+++ b/Classes/Utility/IgnoreTouches/IgnoreTouchesView.swift
@@ -15,9 +15,22 @@ import UIKit
 /// This class is meant to be subclassed.
 class IgnoreTouchesView: UIView {
 
+    /// Override this property to specifically select which types of events to ignore
+    private(set) var ignoredTypes: [UIEvent.EventType]? = nil
+
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
         let hitView = super.hitTest(point, with: event)
-        return hitView == self ? nil : hitView
+        let ignored: Bool
+        if let type = event?.type, let ignoredTypes = ignoredTypes {
+            ignored = ignoredTypes.contains(type)
+        } else {
+            ignored = true
+        }
+        if ignored {
+            return hitView == self ? nil : hitView
+        } else {
+            return hitView
+        }
     }
     
 }

--- a/Classes/Utility/TrashView.swift
+++ b/Classes/Utility/TrashView.swift
@@ -31,6 +31,12 @@ final class TrashView: IgnoreTouchesView {
     private let translucentBackgroundCircle: UIImageView
     private let openedTrash: UIImageView
     private let closedTrash: UIImageView
+
+    var completion: (() -> Void)?
+
+    override var ignoredTypes: [UIEvent.EventType]? {
+        return [.touches, .presses]
+    }
     
     init() {
         self.borderCircle = UIImageView()
@@ -41,6 +47,11 @@ final class TrashView: IgnoreTouchesView {
         super.init(frame: .zero)
         
         setUpViews()
+
+        let dropInteraction = UIDropInteraction(delegate: self)
+        addInteraction(dropInteraction)
+
+        isUserInteractionEnabled = true
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -228,5 +239,32 @@ final class TrashView: IgnoreTouchesView {
         else {
             close()
         }
+    }
+}
+
+extension TrashView: UIDropInteractionDelegate {
+    // MARK: - UIDropInteractionDelegate
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidUpdate session: UIDropSession) -> UIDropProposal {
+        return UIDropProposal(operation: .move)
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, performDrop session: UIDropSession) {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        completion?()
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidEnter session: UIDropSession) {
+        UISelectionFeedbackGenerator().selectionChanged()
+        open()
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, sessionDidExit session: UIDropSession) {
+        UISelectionFeedbackGenerator().selectionChanged()
+        close()
+    }
+
+    func dropInteraction(_ interaction: UIDropInteraction, canHandle session: UIDropSession) -> Bool {
+        return true
     }
 }

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Kanvas"
-  spec.version      = "1.2.0"
+  spec.version      = "1.2.1"
   spec.summary      = "A custom camera built for iOS."
   spec.homepage     = "https://github.com/tumblr/kanvas-ios"
   spec.license      = "MPLv2"

--- a/KanvasExample/Podfile.lock
+++ b/KanvasExample/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Kanvas (1.1.1)
+  - Kanvas (1.2.1)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 2.1.4)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Kanvas: 565caff19d90e883194e6e646f6ea994e14fcde5
+  Kanvas: 257eab9c9e3666f990a202e73ff793f399d8dd13
 
 PODFILE CHECKSUM: 14b28dd726149c0d01dba9154d5bb095d9ba6a18
 


### PR DESCRIPTION
* Adds customizable `KanvasStrings.shared` instance with permissions screen strings for customization. Similar to the way we are customizing `KanvasFonts` and `KanvasColors` for now.
* Adds the ability delete a frame from the Multi Editor screen. The `UIDropInteractionDelegate` APIs are used for this.

https://user-images.githubusercontent.com/3250/108441388-3f2fb100-7212-11eb-884a-3365b76fd97b.mp4

* Sets a white color for the Font Selector button when special fonts are used (this must be tested against WordPress iOS to verify the change).

| Before | After |
| ------ | ------|
| ![CleanShot 2021-02-18 at 17 59 14@2x](https://user-images.githubusercontent.com/3250/108441775-1825af00-7213-11eb-85c5-01c36a8769a7.png) | ![CleanShot 2021-02-18 at 17 54 40@2x](https://user-images.githubusercontent.com/3250/108441784-1c51cc80-7213-11eb-9463-3345298c3bfc.png) |

