### PR TITLE
Add multiple item selection to Media Picker

### DIFF
--- a/Classes/Analytics/KanvasAnalyticsProvider.swift
+++ b/Classes/Analytics/KanvasAnalyticsProvider.swift
@@ -7,7 +7,7 @@
 import AVFoundation
 import Foundation
 
-@objc public enum KanvasBrushType: Int {
+public enum KanvasBrushType: Int {
     case pencil, marker, sharpie
 
     public func string() -> String {
@@ -22,7 +22,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasColorSelectionTool: Int {
+public enum KanvasColorSelectionTool: Int {
     case swatch, gradient, eyedropper
 
     public func string() -> String {
@@ -52,7 +52,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasTextAlignment: Int {
+public enum KanvasTextAlignment: Int {
     case left, center, right
 
     public func string() -> String {
@@ -81,7 +81,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasDashboardOpenAction: Int {
+public enum KanvasDashboardOpenAction: Int {
     case tap, swipe
 
     public func string() -> String {
@@ -94,7 +94,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasDashboardDismissAction: Int {
+public enum KanvasDashboardDismissAction: Int {
     case tap, swipe
 
     public func string() -> String {
@@ -107,7 +107,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasMediaType: Int {
+public enum KanvasMediaType: Int {
     case image, video, frames, livePhoto
 
     public func string() -> String {
@@ -124,7 +124,7 @@ import Foundation
     }
 }
 
-@objc public enum KanvasGIFPlaybackMode: Int {
+public enum KanvasGIFPlaybackMode: Int {
     case loop, rebound, reverse
 
     init(from playbackOption: PlaybackOption) {
@@ -151,7 +151,7 @@ import Foundation
 }
 
 /// A protocol for injecting analytics into the Kanvas module
-@objc public protocol KanvasAnalyticsProvider {
+public protocol KanvasAnalyticsProvider {
 
     /// Logs an event when the camera is opened
     ///
@@ -220,7 +220,7 @@ import Foundation
 
     func logMediaPickerDismiss()
 
-    func logMediaPickerPickedMedia(ofType mediaType: KanvasMediaType)
+    func logMediaPickerPickedMedia(ofTypes mediaTypes: [KanvasMediaType])
 
     func logEditorOpen()
 

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -1141,38 +1141,28 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
 
     }
 
-    public func didPick(images: [(UIImage, URL?)]) {
+    public func didPick(media: [PickedMedia]) {
+
+        let mediaTypes = media.map { media -> KanvasMediaType in
+            switch media {
+            case .image:
+                return .image
+            case .video:
+                return .video
+            case .gif:
+                return .frames
+            case .livePhoto:
+                return .livePhoto
+            }
+        }
+
         defer {
-            analyticsProvider?.logMediaPickerPickedMedia(ofType: .image)
-        }
-        let segments: [CameraSegment] = images.map { (image, imageURL) in
-            return segment(image: image, imageURL: imageURL)
+            analyticsProvider?.logMediaPickerPickedMedia(ofTypes: mediaTypes)
         }
 
-        performUIUpdate {
-            self.showPreviewWithSegments(segments, selected: segments.startIndex)
-        }
-    }
-
-    public func didPick(videos urls: [URL]) {
-        defer {
-            analyticsProvider?.logMediaPickerPickedMedia(ofType: .video)
-        }
-
-        let segments: [CameraSegment] = urls.map { url in
-            return segment(video: url)
-        }
-
-        performUIUpdate {
-            self.showPreviewWithSegments(segments, selected: segments.startIndex)
-        }
-    }
-
-    public func didPick(gifs urls: [URL]) {
-        defer {
-            analyticsProvider?.logMediaPickerPickedMedia(ofType: .frames)
-        }
-        urls.forEach({ url in
+        // Handle gifs and live photos separately, as they should not be chosen when multiple selection is enabled.
+        switch media.first {
+        case .gif(let url):
             let mediaInfo: MediaInfo = {
                 return MediaInfo(fromImage: url) ?? MediaInfo(source: .media_library)
             }()
@@ -1180,14 +1170,8 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
                 let segments = frames.map { CameraSegment.image(UIImage(cgImage: $0.image), nil, $0.interval, mediaInfo) }
                 self.showPreviewWithSegments(segments, selected: segments.endIndex)
             }
-        })
-    }
-
-    public func didPick(livePhotos: [(UIImage, URL)]) {
-        defer {
-            analyticsProvider?.logMediaPickerPickedMedia(ofType: .livePhoto)
-        }
-        livePhotos.forEach({ (livePhotoStill, pairedVideo) in
+            return
+        case .livePhoto(let livePhotoStill, let pairedVideo):
             let mediaInfo = MediaInfo(source: .media_library)
             if currentMode.quantity == .single {
                 let segments = [CameraSegment.image(livePhotoStill, pairedVideo, nil, mediaInfo)]
@@ -1196,7 +1180,26 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
             else {
                 assertionFailure("No media picking from stitch yet")
             }
-        })
+            return
+        default:
+            break
+        }
+
+        let segments = media.compactMap { media -> CameraSegment? in
+            switch media {
+            case .image(let image, let imageURL):
+                return segment(image: image, imageURL: imageURL)
+            case .video(let url):
+                return segment(video: url)
+            case .gif, .livePhoto:
+                // Should not get here from code above
+                return nil
+            }
+        }
+
+        performUIUpdate {
+            self.showPreviewWithSegments(segments, selected: segments.startIndex)
+        }
     }
 
     public func didCancel() {

--- a/Classes/MediaPicker/MediaPickerViewController.swift
+++ b/Classes/MediaPicker/MediaPickerViewController.swift
@@ -9,11 +9,15 @@ import UIKit
 import MobileCoreServices
 import Photos
 
+public enum PickedMedia {
+    case image(UIImage, URL?)
+    case video(URL)
+    case gif(URL)
+    case livePhoto(UIImage, URL)
+}
+
 public protocol KanvasMediaPickerViewControllerDelegate: class {
-    func didPick(images: [(UIImage, URL?)])
-    func didPick(videos: [URL])
-    func didPick(gifs: [URL])
-    func didPick(livePhotos: [(UIImage, URL)])
+    func didPick(media: [PickedMedia])
     func didCancel()
     func pickingMediaNotAllowed(reason: String)
 }
@@ -161,19 +165,23 @@ private extension KanvasMediaPickerViewController {
     }
 
     private func pick(frames imageURL: URL) {
-        delegate?.didPick(gifs: [imageURL])
+        let media = PickedMedia.gif(imageURL)
+        delegate?.didPick(media: [media])
     }
 
     private func pick(image: UIImage, url: URL?) {
-        delegate?.didPick(images: [(image: image, url: url)])
+        let media = PickedMedia.image(image, url)
+        delegate?.didPick(media: [media])
     }
 
     private func pick(video url: URL) {
-        delegate?.didPick(videos: [url])
+        let media = PickedMedia.video(url)
+        delegate?.didPick(media: [media])
     }
 
     private func pick(livePhotoStill: UIImage, pairedVideo: URL) {
-        delegate?.didPick(livePhotos: [(still: livePhotoStill, pairedVideo: pairedVideo)])
+        let media = PickedMedia.livePhoto(livePhotoStill, pairedVideo)
+        delegate?.didPick(media: [media])
     }
 
     private func canPick(image: UIImage) -> Bool {

--- a/KanvasExample/KanvasExample/KanvasAnalyticsStub.swift
+++ b/KanvasExample/KanvasExample/KanvasAnalyticsStub.swift
@@ -102,8 +102,9 @@ final public class KanvasAnalyticsStub: NSObject, KanvasAnalyticsProvider {
         logString(string: "logEditorBack")
     }
 
-    public func logMediaPickerPickedMedia(ofType mediaType: KanvasMediaType) {
-        logString(string: "logMediaPickerPickedMedia mediaType:\(mediaType.string())")
+    public func logMediaPickerPickedMedia(ofTypes mediaTypes: [KanvasMediaType]) {
+        let mediaTypes = mediaTypes.map{ $0.string() }.joined(separator: ", ")
+        logString(string: "logMediaPickerPickedMedia mediaTypes:\(mediaTypes)")
     }
 
     public func logEditorFiltersOpen() {


### PR DESCRIPTION
This API change is necessary so that different types of media are selectable at once. The analytics providers will have to update their APIs to expect this and log it appropriately.

* Changes `logMediaPickerPickedMedia` to produce multiple media types for multi-selection:
```diff
--- func logMediaPickerPickedMedia(ofType mediaType: KanvasMediaType)
+++ func logMediaPickerPickedMedia(ofTypes mediaTypes: [KanvasMediaType])
```
* Moves `KanvasAnalyticsProvider` to Swift protocol to avoid issues with handling enums in arrays in Objective-C.
**NOTE: This should be safe since Tumblr's implementation is written in Swift (although it is an @objc class, it can still implement these methods in Swift).**
* Adds a `PickedMedia` type to encapsulate various types of media instead of having multiple delegate methods for each. The implementor can then perform different actions based on this.

See https://github.com/wordpress-mobile/WordPress-iOS/pull/15946 for how this change used in combination with WPMediaPicker in WPiOS.