### PR TITLE
Stories bug fixes for 16.8 release

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -365,8 +365,8 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     private func createNextStepViewController(_ segments: [CameraSegment], selected: Array<CameraSegment>.Index, edits: [EditorViewController.Edit?]?) -> MediaPlayerController {
         let controller: MediaPlayerController
         if settings.features.multipleExports && settings.features.editor {
-            if segments.indices.contains(selected) {
-                multiEditorViewController?.addSegment(segments[selected])
+            segments.forEach { segment in
+                multiEditorViewController?.addSegment(segment)
             }
             controller = multiEditorViewController ?? createStoryViewController(segments, selected: selected, edits: edits)
             multiEditorViewController = controller as? MultiEditorViewController

--- a/Classes/Rendering/MediaPlayer.swift
+++ b/Classes/Rendering/MediaPlayer.swift
@@ -205,6 +205,11 @@ final class MediaPlayer {
     init(renderer: Rendering?) {
         self.renderer = renderer ?? Renderer()
         self.renderer.delegate = self
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        } catch let error {
+            print("Failed to set audio session category: \(error)")
+        }
     }
 
     deinit {

--- a/Classes/Utility/Device.swift
+++ b/Classes/Utility/Device.swift
@@ -20,6 +20,8 @@ public struct KanvasDevice {
     static let iPhone11ScreenHeight = 896
     static let iPhone11ProScreenHeight = 812
     static let iPhone11ProMaxScreenHeight = 896
+    static let iPhone12ProScreenHeight = 844
+    static let iPhone12ProMaxScreenHeight = 926
     static let retinaScreenMinScale: CGFloat = 2.0
     
     // Device type
@@ -44,8 +46,10 @@ public struct KanvasDevice {
     static let isIPhone11: Bool = isIPhone && screenMaxLength == iPhone11ScreenHeight
     static let isIPhone11Pro: Bool = isIPhone && screenMaxLength == iPhone11ProScreenHeight
     static let isIPhone11ProMax: Bool = isIPhone && screenMaxLength == iPhone11ProMaxScreenHeight
+    static let isIPhone12Pro: Bool = isIPhone && screenMaxLength == iPhone12ProScreenHeight
+    static let isIPhone12ProMax: Bool = isIPhone && screenMaxLength == iPhone12ProMaxScreenHeight
     
     // Device group
     // This group represents all devices which have extra safe space at the top and the bottom, as well as rounded screen corners.
-    public static let belongsToIPhoneXGroup: Bool = isIPhoneX || isIPhoneXR || isIPhoneXS || isIPhoneXSMax || isIPhone11 || isIPhone11Pro || isIPhone11ProMax
+    public static let belongsToIPhoneXGroup: Bool = isIPhoneX || isIPhoneXR || isIPhoneXS || isIPhoneXSMax || isIPhone11 || isIPhone11Pro || isIPhone11ProMax || isIPhone12Pro || isIPhone12ProMax
 }

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Kanvas"
-  spec.version      = "1.2.2"
+  spec.version      = "1.2.3"
   spec.summary      = "A custom camera built for iOS."
   spec.homepage     = "https://github.com/tumblr/kanvas-ios"
   spec.license      = "MPLv2"


### PR DESCRIPTION
Related WordPress PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15996

- Appends all added segments to the end of existing segments.
- Adds the iPhone 12 Pro to the `belongsToIPhoneXGroup`. This should be removed in the future to rely on the `safeAreaLayoutGuide` so it's not necessary to keep updating with changing screen sizes.

| Before | After |
| ------ | ----- |
| <a href="https://user-images.githubusercontent.com/3250/109604860-7723d780-7ae1-11eb-9614-279b07298144.png"><img src="https://user-images.githubusercontent.com/3250/109604860-7723d780-7ae1-11eb-9614-279b07298144.png" width="300"></a> | <a href="https://user-images.githubusercontent.com/3250/109604912-8a36a780-7ae1-11eb-98d2-6c92ca00bbf0.png"><img src="https://user-images.githubusercontent.com/3250/109604912-8a36a780-7ae1-11eb-98d2-6c92ca00bbf0.png" width="300"></a> |

## Testing

### Appending Segments
- Open the editor
- Select media from your library
- Tap the + icon in the lower right to add more media
- Select multiple items
- Ensure that all items are appended to the set of frames

### iPhone 12 Pro
- Open the Editor on iPhone 12 Pro (simulator works fine)
- Select media from your library
- Ensure that the frames are in a portrait aspect ratio and are not squished as seen above.