### PR TITLE
Stories: Scale to fill rendering + post-export overlays bug fixes

### DIFF
--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -120,8 +120,11 @@ private struct EditorViewConstants {
 final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelegate {
 
     func didRenderRectChange(rect: CGRect) {
-        drawingCanvasConstraints.update(with: rect)
-        movableViewCanvasConstraints.update(with: rect)
+        if playerView?.contentMode != .scaleToFill {
+            // When scaling to fill we don't need to update these views as they are already sized correctly.
+            drawingCanvasConstraints.update(with: rect)
+            movableViewCanvasConstraints.update(with: rect)
+        }
         delegate?.didRenderRectChange(rect: rect)
     }
 

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -374,6 +374,9 @@ extension MultiEditorViewController: EditorControllerDelegate {
                 editor.export { [weak self, editor] result in
                     let _ = editor // strong reference until the export completes
                     self?.exportHandler.handleExport(result, for: idx)
+                    if let selected = self?.selected {
+                        self?.loadEditor(for: selected)
+                    }
                 }
             }
         })

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Kanvas"
-  spec.version      = "1.2.4"
+  spec.version      = "1.2.5"
   spec.summary      = "A custom camera built for iOS."
   spec.homepage     = "https://github.com/tumblr/kanvas-ios"
   spec.license      = "MPLv2"


### PR DESCRIPTION
WordPress PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16109

### 🐞 Text disappears when using OpenGL + `scaleToFill` 

This was an alignment issue with text when using OpenGL + `scaleToFill` content mode.

<details>
  <summary><strong>Demo</strong></summary>
Notice the disappearing text after the confirm button is pressed.
<table>
  <tr>
    <th>Before</th>
    <th>After</th> 
  </tr>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/3250/111414450-a6237700-86a5-11eb-8ef7-dfc69614651a.mp4"/></td>
    <td><video src="https://user-images.githubusercontent.com/3250/111414415-96a42e00-86a5-11eb-8422-9216ad73857a.mp4"/></td>
  </tr>
</table>
</details>

We now check the player's content mode before adjusting the size of the drawing & movable canvas views. These views are already properly sized to match the full size of the editor so we don't need to change them any further.

https://github.com/tumblr/kanvas-ios/blob/6803838b0cd687050046a6087f860d4ffed06717/Classes/Editor/EditorView.swift#L123-L127

### 🐞 Overlays disappear after exposing

Overlays were lost after exporting media. Because the Prepublishing sheet can be dismissed in WP-iOS, this causes text to be lost if the user goes back.

<details>
  <summary><strong>Demo</strong></summary>
Notice how the text label disappears after dismissing the Prepublishing Sheet.
<table>
  <tr>
    <th>Before</th>
    <th>After</th> 
  </tr>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/3250/111415273-2c8c8880-86a7-11eb-887e-c80d35d6d2ed.mov"/></td>
    <td><video src="https://user-images.githubusercontent.com/3250/111415109-e59e9300-86a6-11eb-864a-0d985be558b0.mp4"/></td>
  </tr>
</table>
</details>

We are reusing a single instance of `MovableViewCanvas` and it is not re-added to the current editor after exporting. It probably makes more sense to serialize the instance and create a new one but that change is more than we want to make after a code freeze.

This addition reloads the editor after export is complete to ensure all archived data and views are present:

https://github.com/tumblr/kanvas-ios/blob/6803838b0cd687050046a6087f860d4ffed06717/Classes/Editor/MultiEditor/MultiEditorViewController.swift#L377-L379