### PR TITLE
Add Aspect Ratio setting to resize + crop media

### DIFF
--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -120,8 +120,12 @@ private struct EditorViewConstants {
 final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelegate {
 
     func didRenderRectChange(rect: CGRect) {
-        drawingCanvasConstraints.update(with: rect)
-        movableViewCanvasConstraints.update(with: rect)
+        if playerView?.contentMode != .scaleToFill {
+            // Any content mode which isn't explicitly filling the frame needs to adjust the drawing / canvas area
+            // Since `scaleToFill` always fills the provided frame, leave sizing alone since they match rendering area at setup.
+            drawingCanvasConstraints.update(with: rect)
+            movableViewCanvasConstraints.update(with: rect)
+        }
         delegate?.didRenderRectChange(rect: rect)
     }
 

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -615,10 +615,10 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         addSubview(drawingMenuContainer)
         drawingMenuContainer.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            drawingMenuContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
-            drawingMenuContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            drawingMenuContainer.topAnchor.constraint(equalTo: topAnchor),
-            drawingMenuContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
+            drawingMenuContainer.leadingAnchor.constraint(equalTo: playerView?.leadingAnchor ?? leadingAnchor),
+            drawingMenuContainer.trailingAnchor.constraint(equalTo: playerView?.trailingAnchor ?? trailingAnchor),
+            drawingMenuContainer.topAnchor.constraint(equalTo: playerView?.topAnchor ?? topAnchor),
+            drawingMenuContainer.bottomAnchor.constraint(equalTo: playerView?.bottomAnchor ?? bottomAnchor)
         ])
     }
     

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -187,10 +187,10 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     private lazy var drawingCanvasConstraints: FullViewConstraints = {
         return FullViewConstraints(
             view: drawingCanvas,
-            top: drawingCanvas.topAnchor.constraint(equalTo: topAnchor),
-            bottom: drawingCanvas.bottomAnchor.constraint(equalTo: bottomAnchor),
-            leading: drawingCanvas.leadingAnchor.constraint(equalTo: leadingAnchor),
-            trailing: drawingCanvas.trailingAnchor.constraint(equalTo: trailingAnchor)
+            top: drawingCanvas.topAnchor.constraint(equalTo: playerView?.topAnchor ?? topAnchor),
+            bottom: drawingCanvas.bottomAnchor.constraint(equalTo: playerView?.bottomAnchor ?? bottomAnchor),
+            leading: drawingCanvas.leadingAnchor.constraint(equalTo: playerView?.leadingAnchor ?? leadingAnchor),
+            trailing: drawingCanvas.trailingAnchor.constraint(equalTo: playerView?.trailingAnchor ?? trailingAnchor)
         )
     }()
 
@@ -199,10 +199,10 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     private lazy var movableViewCanvasConstraints = {
         return FullViewConstraints(
             view: movableViewCanvas,
-            top: movableViewCanvas.topAnchor.constraint(equalTo: topAnchor),
-            bottom: movableViewCanvas.bottomAnchor.constraint(equalTo: bottomAnchor),
-            leading: movableViewCanvas.leadingAnchor.constraint(equalTo: leadingAnchor),
-            trailing: movableViewCanvas.trailingAnchor.constraint(equalTo: trailingAnchor)
+            top: movableViewCanvas.topAnchor.constraint(equalTo: playerView?.topAnchor ?? topAnchor),
+            bottom: movableViewCanvas.bottomAnchor.constraint(equalTo: playerView?.bottomAnchor ?? bottomAnchor),
+            leading: movableViewCanvas.leadingAnchor.constraint(equalTo: playerView?.leadingAnchor ?? leadingAnchor),
+            trailing: movableViewCanvas.trailingAnchor.constraint(equalTo: playerView?.trailingAnchor ?? trailingAnchor)
         )
     }()
 
@@ -222,6 +222,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     
     weak var delegate: EditorViewDelegate?
     private var mediaContentMode: UIView.ContentMode
+    private var aspectRatio: CGFloat?
     
     @available(*, unavailable, message: "use init() instead")
     required public init?(coder aDecoder: NSCoder) {
@@ -239,6 +240,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
          showQuickPostButton: Bool,
          showBlogSwitcher: Bool,
          confirmAtTop: Bool,
+         aspectRatio: CGFloat?,
          quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
          tagCollection: UIView?,
          metalContext: MetalContext?,
@@ -255,6 +257,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         self.showQuickPostButton = showQuickPostButton
         self.showBlogSwitcher = showBlogSwitcher
         self.confirmAtTop = confirmAtTop
+        self.aspectRatio = aspectRatio
         self.quickBlogSelectorCoordinator = quickBlogSelectorCoordinator
         self.tagCollection = tagCollection
         self.metalContext = metalContext
@@ -327,7 +330,24 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     private func setupPlayer() {
         let playerView = MediaPlayerView(metalContext: metalContext, mediaContentMode: mediaContentMode)
         playerView.delegate = self
-        playerView.add(into: self)
+
+        if let aspectRatio = aspectRatio {
+            playerView.translatesAutoresizingMaskIntoConstraints = false
+            self.addSubview(playerView)
+
+            let topConstraint = playerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
+            topConstraint.priority = .defaultHigh
+            NSLayoutConstraint.activate([
+                playerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                playerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                playerView.widthAnchor.constraint(equalTo: playerView.heightAnchor, multiplier: aspectRatio, constant: 0),
+                topConstraint,
+                playerView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor)
+            ])
+        } else {
+            playerView.add(into: self)
+        }
+
         self.playerView = playerView
     }
 
@@ -560,10 +580,10 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         
         addSubview(textMenuContainer)
         NSLayoutConstraint.activate([
-            textMenuContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
-            textMenuContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            textMenuContainer.topAnchor.constraint(equalTo: topAnchor),
-            textMenuContainer.bottomAnchor.constraint(equalTo: bottomAnchor)
+            textMenuContainer.leadingAnchor.constraint(equalTo: playerView?.leadingAnchor ?? leadingAnchor),
+            textMenuContainer.trailingAnchor.constraint(equalTo: playerView?.trailingAnchor ?? trailingAnchor),
+            textMenuContainer.topAnchor.constraint(equalTo: playerView?.topAnchor ?? topAnchor),
+            textMenuContainer.bottomAnchor.constraint(equalTo: playerView?.bottomAnchor ?? bottomAnchor)
         ])
     }
     

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -133,6 +133,11 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
     
     weak var playerView: MediaPlayerView?
 
+    var exportSize: CGSize {
+        let exportView = playerView ?? self
+        return CGSize(width: exportView.bounds.width * exportView.contentScaleFactor, height: exportView.bounds.height * exportView.contentScaleFactor)
+    }
+
     private let mainActionMode: MainActionMode
     private let confirmButton = UIButton()
     private let closeButton = UIButton()

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -341,16 +341,27 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         playerView.delegate = self
 
         if let aspectRatio = aspectRatio {
+            playerView.layer.masksToBounds = true
+            playerView.layer.cornerRadius = 12
             playerView.translatesAutoresizingMaskIntoConstraints = false
             self.addSubview(playerView)
 
-            let topConstraint = playerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
-            topConstraint.priority = .defaultHigh
+            let bottomConstraint: NSLayoutConstraint
+            let topConstraint: NSLayoutConstraint
+            if Device.belongsToIPhoneXGroup {
+                bottomConstraint = playerView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+                topConstraint = playerView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
+            } else {
+                bottomConstraint = playerView.bottomAnchor.constraint(equalTo: bottomAnchor)
+                topConstraint = playerView.topAnchor.constraint(equalTo: topAnchor)
+            }
             NSLayoutConstraint.activate([
-                playerView.leadingAnchor.constraint(equalTo: leadingAnchor),
-                playerView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                playerView.centerXAnchor.constraint(equalTo: centerXAnchor),
+                playerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+                playerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
                 playerView.widthAnchor.constraint(equalTo: playerView.heightAnchor, multiplier: aspectRatio, constant: 0),
                 topConstraint,
+                bottomConstraint,
                 playerView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor)
             ])
         } else {
@@ -549,7 +560,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
 
             let verticalPositioning: [NSLayoutConstraint]
             if confirmAtTop {
-                verticalPositioning = [collectionContainer.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)]
+                verticalPositioning = [collectionContainer.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -KanvasEditorDesign.shared.editorViewButtonBottomMargin)]
             } else {
                 verticalPositioning = [collectionContainer.centerYAnchor.constraint(equalTo: confirmOrPostButton().centerYAnchor)]
             }

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -241,6 +241,7 @@ public final class EditorViewController: UIViewController, MediaPlayerController
                                     showQuickPostButton: settings.showQuickPostButtonInEditor,
                                     showBlogSwitcher: settings.showBlogSwitcherInEditor,
                                     confirmAtTop: settings.features.editorConfirmAtTop,
+                                    aspectRatio: settings.aspectRatio,
                                     quickBlogSelectorCoordinator: quickBlogSelectorCoordinator,
                                     tagCollection: tagCollection,
                                     metalContext: metalContext,

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -813,7 +813,8 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     }
 
     private var exportSize: CGSize? {
-        return settings.features.scaleMediaToFill ? CGSize(width: editorView.frame.width * editorView.contentScaleFactor, height: editorView.frame.height * editorView.contentScaleFactor) : nil
+        let exportSize = editorView.exportSize
+        return settings.features.scaleMediaToFill ? exportSize : nil
     }
 
     private func createFinalGIF(segments: [CameraSegment], mediaInfo: MediaInfo, archive: Data, exportAction: KanvasExportAction) {

--- a/Classes/Editor/Text/EditorTextController.swift
+++ b/Classes/Editor/Text/EditorTextController.swift
@@ -269,7 +269,12 @@ final class EditorTextController: UIViewController, EditorTextViewDelegate, Colo
     @objc func keyboardWillShow(notification: NSNotification) {
         if let keyboardFrame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
             let keyboardRectangle = keyboardFrame.cgRectValue
-            textView.moveToolsUp(distance: keyboardRectangle.height)
+
+            let bottom = CGPoint(x: view.frame.minX, y: view.frame.maxY)
+            let difference = keyboardRectangle.maxY - view.convert(bottom, to: nil).y
+
+            let heightDiff = keyboardRectangle.height - difference
+            textView.moveToolsUp(distance: heightDiff)
         }
     }
     

--- a/Classes/Settings/CameraSettings.swift
+++ b/Classes/Settings/CameraSettings.swift
@@ -312,6 +312,9 @@ public struct CameraFeatures {
     /// The Font Selector button uses the currently selected font for its label
     public var fontSelectorUsesFont: Bool = DefaultCameraSettings.fontFamilyUsesFont
 
+    /// The aspect ratio to pin the Editor View to
+    public var aspectRatio: CGFloat? = nil
+
     override public init() { }
 
 }

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "Kanvas"
-  spec.version      = "1.2.5"
+  spec.version      = "1.2.6"
   spec.summary      = "A custom camera built for iOS."
   spec.homepage     = "https://github.com/tumblr/kanvas-ios"
   spec.license      = "MPLv2"

--- a/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
@@ -32,6 +32,7 @@ final class EditorViewTests: FBSnapshotTestCase {
                               showQuickPostButton: false,
                               showBlogSwitcher: false,
                               confirmAtTop: false,
+                              aspectRatio: nil,
                               quickBlogSelectorCoordinator: nil,
                               tagCollection: nil,
                               metalContext: nil,

--- a/KanvasExample/Podfile.lock
+++ b/KanvasExample/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Kanvas (1.2.4)
+  - Kanvas (1.2.6)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 2.1.4)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Kanvas: 0e1acb8c10e15eea3365f16c086de2443c7703a8
+  Kanvas: 828033a062a8df8bd73e6efd1a09ac438ead4b41
 
 PODFILE CHECKSUM: 14b28dd726149c0d01dba9154d5bb095d9ba6a18
 

--- a/KanvasExample/Podfile.lock
+++ b/KanvasExample/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - Kanvas (1.2.3)
+  - Kanvas (1.2.4)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 2.1.4)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  Kanvas: 97860c54ea07119c533a80d951ee8c1b39d8f386
+  Kanvas: 0e1acb8c10e15eea3365f16c086de2443c7703a8
 
 PODFILE CHECKSUM: 14b28dd726149c0d01dba9154d5bb095d9ba6a18
 


### PR DESCRIPTION
WordPress PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16229

- Adds a new `CameraSettings.aspectRatio` value
- Constrains player and editor views to the `CameraSettings.aspectRatio` value.

<a href="https://user-images.githubusercontent.com/3250/114083673-86c6d680-986c-11eb-9808-e2a2ec48ac27.PNG"><img src="https://user-images.githubusercontent.com/3250/114083673-86c6d680-986c-11eb-9808-e2a2ec48ac27.PNG" width="300"></a>