### PR TITLE
Fixes a crash when recording & multitasking

### DIFF
--- a/Classes/Recording/VideoOutputHandler.swift
+++ b/Classes/Recording/VideoOutputHandler.swift
@@ -41,7 +41,6 @@ final class VideoOutputHandler: NSObject, VideoOutputHandlerProtocol {
     private var audioInput: AVAssetWriterInput?
     private var recordedVideoFrameFirst: Bool = false
     private var videoQueue: DispatchQueue = DispatchQueue(label: VideoHandlerConstants.queue)
-    private let stopRecordingSemaphore = DispatchSemaphore(value: 0)
 
     // MARK: - external methods
 
@@ -83,15 +82,16 @@ final class VideoOutputHandler: NSObject, VideoOutputHandlerProtocol {
         else if let pixelBuffer = currentVideoPixelBuffer, let presentationTime = currentPresentationTime {
             processVideoPixelBuffer(pixelBuffer, presentationTime: presentationTime)
         }
-
-        stopRecordingSemaphore.signal()
     }
 
     /// Stops recording video and exports as a mp4
     ///
     /// - Parameter completion: success boolean if asset writer completed
     func stopRecordingVideo(completion: @escaping (Bool) -> Void) {
-        stopRecordingSemaphore.wait()
+        guard recording else {
+            completion(false)
+            return
+        }
         recording = false
 
         if let sampleBuffer = currentVideoSampleBuffer {


### PR DESCRIPTION
While recording a video and dismissing the app through multitasking, the app will crash with a `SIGKILL` error. The crash line indicates a stall with a `semaphore.wait()` call when stopping the recording:

https://github.com/tumblr/kanvas-ios/blob/bc3dff580897d0170fce3818b5179a44263125e5/Classes/Recording/VideoOutputHandler.swift#L94

The reason seems to indicate a timeout issue with watchdog causing the crash:

```
Termination Description: SPRINGBOARD, <RBSTerminateContext| domain:10 code:0x8BADF00D explanation:scene-update watchdog transgression: application<org.wordpress>:10245 exhausted real (wall clock) time allowance of 10.00 seconds | ProcessVisibility: Foreground | ProcessState: Running | WatchdogEvent: scene-update | WatchdogVisibility: Background | WatchdogCPUStatistics: ( | "Elapsed total CPU time (seconds): 13.150 (user 13.150, system 0.000), 22% CPU", | "Elapsed application CPU time (seconds): 0.013, 0% CPU" | ) reportType:CrashLog maxTerminationResistance:Interactive>
```

It's not safe to wait for a semaphore while on the main thread and I believe that's what we're seeing here.

The minor change switches back to the original local property to avoid calling the stop method multiple times. All of the call sites using the `stopRecordingVideo` and `startRecordingVideo` methods appear to occur on the main thread so I don't believe it's necessary to dispatch to a synchronous queue to avoid race conditions.

## Testing

1. Begin recording by holding the record button
2. Swipe up from the bottom to enter multitasking
3. Continue swiping up to go back to the home screen
4. Tap the App's icon on the home screen
5. Verify that the recording screen is shown and interaction is possible