### PR TITLE
Improve multi export loading state handling + remove OpenGL assertions

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -899,6 +899,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
             logMediaCreation(action: action, clipsCount: cameraInputController.segments().count, length: CMTimeGetSeconds(asset.duration))
             performUIUpdate { [weak self] in
                 if let self = self {
+                    self.existingEditor?.hideLoading()
                     self.handleCloseSoon(action: action)
                     self.delegate?.didCreateMedia(self, media: [.success(media)], exportAction: action)
                 }
@@ -906,6 +907,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         } else {
             performUIUpdate { [weak self] in
                 if let self = self {
+                    self.existingEditor?.hideLoading()
                     self.handleCloseSoon(action: action)
                     self.delegate?.didCreateMedia(self, media: [.failure(CameraControllerError.exportFailure)], exportAction: action)
                 }
@@ -920,6 +922,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
             logMediaCreation(action: action, clipsCount: 1, length: 0)
             performUIUpdate { [weak self] in
                 if let self = self {
+                    self.existingEditor?.hideLoading()
                     self.handleCloseSoon(action: action)
                     self.delegate?.didCreateMedia(self, media: [.success(media)], exportAction: action)
                 }
@@ -928,6 +931,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         else {
             performUIUpdate { [weak self] in
                 if let self = self {
+                    self.existingEditor?.hideLoading()
                     self.handleCloseSoon(action: action)
                     self.delegate?.didCreateMedia(self, media: [.failure(CameraControllerError.exportFailure)], exportAction: action)
                 }
@@ -939,15 +943,23 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         guard settings.features.multipleExports == false else { return }
         guard let url = url, let info = info, let size = size, size != .zero else {
             performUIUpdate {
+                self.existingEditor?.hideLoading()
                 self.handleCloseSoon(action: action)
                 self.delegate?.didCreateMedia(self, media: [.failure(CameraControllerError.exportFailure)], exportAction: action)
             }
             return
         }
         performUIUpdate {
+            self.existingEditor?.hideLoading()
             self.handleCloseSoon(action: action)
             let media = KanvasMedia(unmodified: nil, output: url, info: info, size: size, archive: nil, type: .frames)
             self.delegate?.didCreateMedia(self, media: [.success(media)], exportAction: action)
+        }
+    }
+
+    public func didFailExporting() {
+        performUIUpdate {
+            self.existingEditor?.hideLoading()
         }
     }
 
@@ -972,7 +984,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
 
             let publishers = archiver.handle(exports: exports)
             self.exportCancellable = publishers.receive(on: DispatchQueue.main).sink { completion in
-
+                self.multiEditorViewController?.hideLoading()
             } receiveValue: { items in
                 self.handleCloseSoon(action: .previewConfirm)
                 self.delegate?.didCreateMedia(self, media: items, exportAction: .post)

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -76,7 +76,7 @@ class MultiEditorViewController: UIViewController {
 
     private var exportingEditors: [EditorViewController]?
 
-    private weak var currentEditor: EditorViewController?
+    private(set) weak var currentEditor: EditorViewController?
 
     init(settings: CameraSettings,
          frames: [Frame],
@@ -317,6 +317,9 @@ extension MultiEditorViewController: EditorControllerDelegate {
     }
     
     func didFinishExportingFrames(url: URL?, size: CGSize?, info: MediaInfo?, archive: Data?, action: KanvasExportAction, mediaChanged: Bool) {
+    }
+
+    func didFailExporting() {
     }
     
     func dismissButtonPressed() {

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -127,11 +127,13 @@ class MultiEditorViewController: UIViewController {
         clipsController.select(index: selected ?? 0)
     }
 
-    func loadEditor(for index: Int) {
+    func loadEditor(for index: Int, current: Bool = true) {
         let frame = frames[index]
         if let editor = delegate?.editor(segment: frame.segment, edit: frame.edit) {
-            currentEditor?.stopPlayback()
-            currentEditor?.unloadFromParentViewController()
+            if current {
+                currentEditor?.stopPlayback()
+                currentEditor?.unloadFromParentViewController()
+            }
             let additionalPadding: CGFloat = 10 // Extra padding for devices that don't have safe areas (which provide some padding by default).
             let bottom: CGFloat
             if view.safeAreaInsets.bottom > 0 {
@@ -145,7 +147,11 @@ class MultiEditorViewController: UIViewController {
                 self?.clipsController.removeDraggingClip()
             }
             load(childViewController: editor, into: editorContainer)
-            currentEditor = editor
+            if current {
+                currentEditor = editor
+            } else {
+                editor.view.alpha = 0.0
+            }
         }
     }
         
@@ -378,7 +384,7 @@ extension MultiEditorViewController: EditorControllerDelegate {
                     let _ = editor // strong reference until the export completes
                     self?.exportHandler.handleExport(result, for: idx)
                     if let selected = self?.selected {
-                        self?.loadEditor(for: selected)
+                        self?.loadEditor(for: selected, current: false)
                     }
                 }
             }

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -317,15 +317,19 @@ extension MultiEditorViewController: EditorControllerDelegate {
     }
 
     func didFinishExportingVideo(url: URL?, info: MediaInfo?, archive: Data?, action: KanvasExportAction, mediaChanged: Bool) {
+        // Handled by MultiEditorExportHandler
     }
     
     func didFinishExportingImage(image: UIImage?, info: MediaInfo?, archive: Data?, action: KanvasExportAction, mediaChanged: Bool) {
+        // Handled by MultiEditorExportHandler
     }
     
     func didFinishExportingFrames(url: URL?, size: CGSize?, info: MediaInfo?, archive: Data?, action: KanvasExportAction, mediaChanged: Bool) {
+        // Handled by MultiEditorExportHandler
     }
 
     func didFailExporting() {
+        // Handled by MultiEditorExportHandler
     }
     
     func dismissButtonPressed() {

--- a/Classes/Rendering/OpenGL/GLPixelBufferView.swift
+++ b/Classes/Rendering/OpenGL/GLPixelBufferView.swift
@@ -8,6 +8,7 @@ import UIKit
 import CoreVideo
 import OpenGLES
 import GLKit
+import os
 
 /// Protocol for GLPixelBufferView
 protocol GLPixelBufferViewDelegate: class {
@@ -18,6 +19,8 @@ protocol GLPixelBufferViewDelegate: class {
 
 /// OpenGL view for rendering a buffer of pixels.
 final class GLPixelBufferView: UIView, PixelBufferView {
+
+    private let log = OSLog(subsystem: "com.tumblr.kanvas", category: "GLPixelBufferView")
 
     private weak var delegate: GLPixelBufferViewDelegate?
 
@@ -104,7 +107,7 @@ final class GLPixelBufferView: UIView, PixelBufferView {
         bail: repeat {
             glFramebufferRenderbuffer(GL_FRAMEBUFFER.ui, GL_COLOR_ATTACHMENT0.ui, GL_RENDERBUFFER.ui, colorBufferHandle)
             if glCheckFramebufferStatus(GL_FRAMEBUFFER.ui) != GL_FRAMEBUFFER_COMPLETE.ui {
-                assertionFailure("Failure with framebuffer generation")
+                os_log("Failure with framebuffer generation", log: log, type: .error)
                 success = false
                 break bail
             }
@@ -168,7 +171,7 @@ final class GLPixelBufferView: UIView, PixelBufferView {
         if frameBufferHandle == 0 {
             let success = self.initializeBuffers()
             if !success {
-                assertionFailure("Problem initializing OpenGL buffers.")
+                os_log("Problem initializing OpenGL buffers.", log: log, type: .error)
                 return
             }
         }


### PR DESCRIPTION
**No public API changes**

* Removes OpenGL assertions which appear to be non-critical.
  * These assertions are firing in debug builds with editors in the background but do not occur in other builds where export works properly.
  * They are replaced by `os_log` `.error` log messages
*  `hideLoading` method calls are moved out of the individual export callbacks and into the delegate method. This allows the delegate to choose to handle them in bulk -- as `MultiEditorViewController` with `MultiEditorExportHandler` -- or to call `hideLoading` after a single export completes.
  *  This would be better handled with a larger export refactor. We could use a Combine Publisher for export results and allow the caller to handle them that way in the future.
* The `loadEditor` method now allows the caller to specify whether the current editor is being loaded. For multiple exports this value is set to `false` and the current editor is left displayed.