### PR TITLE
Improve memory pressure while exporting GIFs

### DIFF
--- a/Classes/MediaFormats/GIFEncoder.swift
+++ b/Classes/MediaFormats/GIFEncoder.swift
@@ -128,13 +128,15 @@ final class GIFEncoderImageIO: GIFEncoder {
             CGImageDestinationSetProperties(destination, getFileProperties(loopCount) as CFDictionary)
 
             for frame in frames {
-                if let image = frame.image.cgImage {
-                    CGImageDestinationAddImage(destination, image, getFrameProperties(frame.interval) as CFDictionary)
-                }
-                else {
-                    assertionFailure("GIF frame missing")
-                    completionMain(nil)
-                    return
+                autoreleasepool {
+                    if let image = frame.image.cgImage {
+                        CGImageDestinationAddImage(destination, image, getFrameProperties(frame.interval) as CFDictionary)
+                    }
+                    else {
+                        assertionFailure("GIF frame missing")
+                        completionMain(nil)
+                        return
+                    }
                 }
             }
 

--- a/Classes/Rendering/MediaExporter.swift
+++ b/Classes/Rendering/MediaExporter.swift
@@ -95,12 +95,14 @@ final class MediaExporter: MediaExporting {
         DispatchQueue.global(qos: .default).async {
             var time: TimeInterval = 0
             for frame in frames {
-                self.export(image: frame.image, time: time, toSize: toSize) { (image, error) in
-                    guard error == nil, let image = image else {
-                        return
+                autoreleasepool {
+                    self.export(image: frame.image, time: time, toSize: toSize) { (image, error) in
+                        guard error == nil, let image = image else {
+                            return
+                        }
+                        time += frame.interval
+                        processedFrames.append((image: image, interval: frame.interval))
                     }
-                    time += frame.interval
-                    processedFrames.append((image: image, interval: frame.interval))
                 }
             }
             DispatchQueue.main.async {

--- a/KanvasExample/Gemfile.lock
+++ b/KanvasExample/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
@@ -87,4 +90,4 @@ DEPENDENCIES
   cocoapods (= 1.9.3)!
 
 BUNDLED WITH
-   2.0.2
+   2.2.10


### PR DESCRIPTION
This PR updates the exporting loops for creating GIF to be wrapped with autorelease blocks so the memory pressure is smaller when exporting then.

Related bug: https://jira.tumblr.net/browse/PROD-15147

How to test: 

- Start the sample project
- Try to export a larger GIF ( you can get a GIF here: https://zikkimyeyin.tumblr.com/post/651438616631033856 )
- Check that the memory being used does not go over the limits.

