### PR TITLE
Version 1.0.4 with fix for export gifs

### DIFF
--- a/Classes/MediaFormats/GIFEncoder.swift
+++ b/Classes/MediaFormats/GIFEncoder.swift
@@ -128,13 +128,15 @@ final class GIFEncoderImageIO: GIFEncoder {
             CGImageDestinationSetProperties(destination, getFileProperties(loopCount) as CFDictionary)
 
             for frame in frames {
-                if let image = frame.image.cgImage {
-                    CGImageDestinationAddImage(destination, image, getFrameProperties(frame.interval) as CFDictionary)
-                }
-                else {
-                    assertionFailure("GIF frame missing")
-                    completionMain(nil)
-                    return
+                autoreleasepool {
+                    if let image = frame.image.cgImage {
+                        CGImageDestinationAddImage(destination, image, getFrameProperties(frame.interval) as CFDictionary)
+                    }
+                    else {
+                        assertionFailure("GIF frame missing")
+                        completionMain(nil)
+                        return
+                    }
                 }
             }
 

--- a/Classes/Rendering/MediaExporter.swift
+++ b/Classes/Rendering/MediaExporter.swift
@@ -97,12 +97,14 @@ final class MediaExporter: MediaExporting {
         DispatchQueue.global(qos: .default).async {
             var time: TimeInterval = 0
             for frame in frames {
-                self.export(image: frame.image, time: time) { (image, error) in
-                    guard error == nil, let image = image else {
-                        return
+                autoreleasepool {
+                    self.export(image: frame.image, time: time) { (image, error) in
+                        guard error == nil, let image = image else {
+                            return
+                        }
+                        time += frame.interval
+                        processedFrames.append((image: image, interval: frame.interval))
                     }
-                    time += frame.interval
-                    processedFrames.append((image: image, interval: frame.interval))
                 }
             }
             DispatchQueue.main.async {

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
@@ -87,4 +90,4 @@ DEPENDENCIES
   cocoapods (= 1.9.1)!
 
 BUNDLED WITH
-   2.1.4
+   2.2.10

--- a/KanvasCamera.podspec
+++ b/KanvasCamera.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "KanvasCamera"
-  spec.version      = "1.0.3"
+  spec.version      = "1.0.4"
   spec.summary      = "A custom camera built for iOS."
   spec.homepage     = "https://github.com/tumblr/kanvas-ios"
   spec.license      = "MPLv2"

--- a/KanvasCameraExample/Gemfile.lock
+++ b/KanvasCameraExample/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
@@ -87,4 +90,4 @@ DEPENDENCIES
   cocoapods (= 1.9.3)!
 
 BUNDLED WITH
-   2.0.2
+   2.2.10

--- a/KanvasCameraExample/Podfile.lock
+++ b/KanvasCameraExample/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - KanvasCamera (1.0.2)
+  - KanvasCamera (1.0.4)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 2.1.4)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  KanvasCamera: 378d06b5c8c88d730d86724d316c009eae447ea4
+  KanvasCamera: 70dcf872ab836349b47d6694920d08f47b11eab4
 
 PODFILE CHECKSUM: 39525ef5bc2a8e9b830bc7ee55300553eb114b04
 

--- a/KanvasCameraExample/Pods/Local Podspecs/KanvasCamera.podspec.json
+++ b/KanvasCameraExample/Pods/Local Podspecs/KanvasCamera.podspec.json
@@ -1,12 +1,12 @@
 {
   "name": "KanvasCamera",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "summary": "A custom camera built for iOS.",
   "homepage": "https://github.com/tumblr/kanvas-ios",
   "license": "MPLv2",
   "source": {
     "git": "https://github.com/tumblr/kanvas-ios.git",
-    "tag": "1.0.2"
+    "tag": "1.0.4"
   },
   "authors": {
     "Jimmy Schementi": "jimmys@tumblr.com",

--- a/KanvasCameraExample/Pods/Manifest.lock
+++ b/KanvasCameraExample/Pods/Manifest.lock
@@ -4,7 +4,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.1.4)
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
-  - KanvasCamera (1.0.2)
+  - KanvasCamera (1.0.4)
 
 DEPENDENCIES:
   - FBSnapshotTestCase (= 2.1.4)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
-  KanvasCamera: 378d06b5c8c88d730d86724d316c009eae447ea4
+  KanvasCamera: 70dcf872ab836349b47d6694920d08f47b11eab4
 
 PODFILE CHECKSUM: 39525ef5bc2a8e9b830bc7ee55300553eb114b04
 

--- a/KanvasCameraExample/Pods/Target Support Files/KanvasCamera/ResourceBundle-KanvasCamera-KanvasCamera-Info.plist
+++ b/KanvasCameraExample/Pods/Target Support Files/KanvasCamera/ResourceBundle-KanvasCamera-KanvasCamera-Info.plist
@@ -13,7 +13,7 @@
   <key>CFBundlePackageType</key>
   <string>BNDL</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.2</string>
+  <string>1.0.4</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/KanvasExample/KanvasExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/KanvasExample/KanvasExample.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR updates the exporting loops for creating GIF to be wrapped with autorelease blocks so the memory pressure is smaller when exporting then.

Related bug: https://jira.tumblr.net/browse/PROD-15147

How to test: 

- Start the sample project
- Ensure metal options are active.
- Try to export a larger GIF ( you can get a GIF here: https://zikkimyeyin.tumblr.com/post/651438616631033856 )
- Check that the memory being used does not go over the limits.

