### PR TITLE
Fix kernel identify shader on Metal.

### DIFF
--- a/Resources/MetalShaders/shaders.metal
+++ b/Resources/MetalShaders/shaders.metal
@@ -56,10 +56,10 @@ kernel void kernelIdentity(texture2d<float, access::read> inTexture [[ texture(0
                            texture2d<float, access::write> outTexture [[ texture(1) ]],
                            uint2 gid [[ thread_position_in_grid ]])
 {
-    uint inWidth = inTexture.get_width();
-    uint outWidth = outTexture.get_width();
+    int inWidth = inTexture.get_width();
+    int outWidth = outTexture.get_width();
     
-    uint offset = (inWidth - outWidth) > 0 ? (inWidth - outWidth) / 2 : 0;
+    int offset = (inWidth - outWidth) > 0 ? (inWidth - outWidth) / 2 : 0;
     uint2 adjusted = uint2(gid.x + offset, gid.y);
     float4 outColor = inTexture.read(adjusted);
     outTexture.write(outColor, gid);


### PR DESCRIPTION
Fixes #120

See: https://jira.tumblr.net/browse/PROD-15637

### Changes

This PR changes the variable types on the kernelIdentity shader in order for this check to work properly:

`(inWidth - outWidth) > 0`

Using `uint` will make this comparation to always be true even when outWidth is larger than inWidth.
It will also cause the offsset to overflow and be a large number and cause the bug we observe.

Up until now we have been *lucky* that the outTexture was always smaller, and that is also why the bug only manifested itself on certain hardware depending of the screen sizes and video resolution calculations.

### How to test

 - Start the demo app on a real device. On my tests I need to use an iPhone 12 Pro to see the original bug.
 -  Disable Camera Open GL and Camera Open GL Capture
 -  Enable Camera Metal and Metal Filters
 -  Enable Scale Media To Fill
 - Tap on Start
 - Tap and hold on the shutter button to record a video
 - Release the button
 - Check that video preview is working properly
