### PR TITLE
Move EditorView delegate to initializer

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -397,7 +397,8 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     }
     
     private func createEditorViewController(_ segments: [CameraSegment], selected: Array<CameraSegment>.Index, edit: EditorViewController.Edit? = nil, drawing: IgnoreTouchesView? = nil) -> EditorViewController {
-        let controller = EditorViewController(settings: settings,
+        let controller = EditorViewController(delegate: self,
+                                              settings: settings,
                                               segments: segments,
                                               assetsHandler: segmentsHandler,
                                               exporterClass: MediaExporter.self,
@@ -411,7 +412,6 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         controller.editorView.movableViewCanvas.trashCompletion = { [weak self] in
             self?.clipsController.removeDraggingClip()
         }
-        controller.delegate = self
         return controller
     }
 

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -228,7 +228,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         return delegate.getBlogSwitcher()
     }()
     
-    weak var delegate: EditorViewDelegate?
+    private weak var delegate: EditorViewDelegate?
     private var mediaContentMode: UIView.ContentMode
     private var aspectRatio: CGFloat?
     
@@ -273,6 +273,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         self.movableViewCanvas = movableViewCanvas ?? MovableViewCanvas()
         super.init(frame: .zero)
         self.movableViewCanvas.delegate = self
+        setupViews()
     }
 
     func updateUI(forDraggingClip: Bool) {
@@ -287,7 +288,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
         })
     }
     
-    func setupViews() {
+    private func setupViews() {
         setupPlayer()
         setupDrawingCanvas()
         setupMovableViewCanvas()

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -107,7 +107,8 @@ public final class EditorViewController: UIViewController, MediaPlayerController
         }
     }
 
-    var editorView: EditorView
+    // Set immediately after the initializer super call to ensure it is never `nil`.
+    var editorView: EditorView!
 
     var isMuted: Bool {
         return player.isMuted
@@ -267,8 +268,10 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     public static func createEditor(for image: UIImage,
                                     settings: CameraSettings,
                                     stickerProvider: StickerProvider,
-                                    analyticsProvider: KanvasAnalyticsProvider) -> EditorViewController {
-        EditorViewController(settings: settings,
+                                    analyticsProvider: KanvasAnalyticsProvider,
+                                    delegate: EditorControllerDelegate) -> EditorViewController {
+        EditorViewController(delegate: delegate,
+                             settings: settings,
                              segments: [.image(image, nil, nil, MediaInfo(source: .media_library))],
                              assetsHandler: CameraSegmentHandler(),
                              exporterClass: MediaExporter.self,
@@ -280,8 +283,12 @@ public final class EditorViewController: UIViewController, MediaPlayerController
                              tagCollection: nil)
     }
     
-    public static func createEditor(for videoURL: URL, settings: CameraSettings, stickerProvider: StickerProvider) -> EditorViewController {
-        EditorViewController(settings: settings,
+    public static func createEditor(for videoURL: URL,
+                                    settings: CameraSettings,
+                                    stickerProvider: StickerProvider,
+                                    delegate: EditorControllerDelegate) -> EditorViewController {
+        EditorViewController(delegate: delegate,
+                             settings: settings,
                              segments: [.video(videoURL, MediaInfo(source: .media_library))],
                              assetsHandler: CameraSegmentHandler(),
                              exporterClass: MediaExporter.self,
@@ -298,10 +305,12 @@ public final class EditorViewController: UIViewController, MediaPlayerController
                               settings: CameraSettings,
                               stickerProvider: StickerProvider,
                               analyticsProvider: KanvasAnalyticsProvider,
+                              delegate: EditorControllerDelegate,
                               completion: @escaping (EditorViewController) -> Void) {
         GIFDecoderFactory.main().decode(image: url) { frames in
             let segments = CameraSegment.from(frames: frames, info: info)
-            let editor = EditorViewController(settings: settings,
+            let editor = EditorViewController(delegate: delegate,
+                                              settings: settings,
                                               segments: segments,
                                               stickerProvider: stickerProvider,
                                               analyticsProvider: analyticsProvider)
@@ -309,11 +318,13 @@ public final class EditorViewController: UIViewController, MediaPlayerController
         }
     }
 
-    convenience init(settings: CameraSettings,
+    convenience init(delegate: EditorControllerDelegate,
+                     settings: CameraSettings,
                      segments: [CameraSegment],
                      stickerProvider: StickerProvider,
                      analyticsProvider: KanvasAnalyticsProvider) {
-        self.init(settings: settings,
+        self.init(delegate: delegate,
+                  settings: settings,
                   segments: segments,
                   assetsHandler: CameraSegmentHandler(),
                   exporterClass: MediaExporter.self,
@@ -334,7 +345,8 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     ///   - cameraMode: The camera mode that the preview was coming from, if any
     ///   - stickerProvider: Class that will provide the stickers in the editor.
     ///   - analyticsProvider: A class conforming to KanvasAnalyticsProvider
-    init(settings: CameraSettings,
+    init(delegate: EditorControllerDelegate,
+         settings: CameraSettings,
          segments: [CameraSegment],
          assetsHandler: AssetsHandlerType,
          exporterClass: MediaExporting.Type,
@@ -345,6 +357,7 @@ public final class EditorViewController: UIViewController, MediaPlayerController
          quickBlogSelectorCoordinator: KanvasQuickBlogSelectorCoordinating?,
          edit: Edit? = nil,
          tagCollection: UIView?) {
+        self.delegate = delegate
         self.settings = settings
         self.originalSegments = segments
         self.assetsHandler = assetsHandler
@@ -356,22 +369,24 @@ public final class EditorViewController: UIViewController, MediaPlayerController
         self.quickBlogSelectorCoordinater = quickBlogSelectorCoordinator
         self.tagCollection = tagCollection
 
+
+
         let metalContext: MetalContext? = settings.features.metalPreview ? MetalContext.createContext() : nil
         self.player = MediaPlayer(renderer: Renderer(settings: settings, metalContext: metalContext))
         self.player.isMuted = edit?.isMuted == true
         let muteButtonShown = settings.features.muteButton && segments.first?.isVideo == true
-        self.editorView = EditorViewController.editor(delegate: nil,
+
+        super.init(nibName: .none, bundle: .none)
+
+        self.editorView = EditorViewController.editor(delegate: self,
                                                       settings: settings,
                                                       showsMuteButton: muteButtonShown,
                                                       edit: edit,
                                                       quickBlogSelectorCoordinator: quickBlogSelectorCoordinator,
                                                       tagCollection: tagCollection,
                                                       metalContext: metalContext)
-        super.init(nibName: .none, bundle: .none)
-        self.editorView.delegate = self
         self.editorView.muteButtonSelected = player.isMuted
 
-        editorView.delegate = self
         player.playerView = editorView.playerView
         
         self.player.delegate = self
@@ -406,8 +421,6 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     
     override public func viewDidLoad() {
         super.viewDidLoad()
-
-        editorView.setupViews()
 
         view.backgroundColor = .black
         editorView.add(into: view)

--- a/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
@@ -135,8 +135,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         let cameraSettings = settings ?? getCameraSettings()
         let handler = assetsHandler ?? AssetsHandlerStub()
         let analytics = analyticsProvider ?? KanvasAnalyticsStub()
-        let viewController = EditorViewController(settings: cameraSettings, segments: segments, assetsHandler: handler, exporterClass: MediaExporterStub.self, gifEncoderClass: GIFEncoderStub.self, cameraMode: cameraMode, stickerProvider: StickerProviderStub(), analyticsProvider: analytics, quickBlogSelectorCoordinator: nil, tagCollection: nil)
-        viewController.delegate = delegate ?? newDelegateStub()
+        let viewController = EditorViewController(delegate: delegate ?? newDelegateStub(), settings: cameraSettings, segments: segments, assetsHandler: handler, exporterClass: MediaExporterStub.self, gifEncoderClass: GIFEncoderStub.self, cameraMode: cameraMode, stickerProvider: StickerProviderStub(), analyticsProvider: analytics, quickBlogSelectorCoordinator: nil, tagCollection: nil)
         viewController.view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
         return viewController
     }

--- a/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
@@ -39,7 +39,6 @@ final class EditorViewTests: FBSnapshotTestCase {
                               mediaContentMode: .scaleAspectFit,
                               movableViewCanvas: nil)
         view.frame = CGRect(x: 0, y: 0, width: 320, height: 480)
-        view.setupViews()
         return view
     }
     

--- a/KanvasExample/KanvasExampleTests/Editor/MultiEditor/MultiEditorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/MultiEditor/MultiEditorControllerTests.swift
@@ -164,7 +164,8 @@ final class MultiEditorControllerDelegateStub: MultiEditorComposerDelegate {
     }
 
     func editor(segment: CameraSegment, edit: EditorViewController.Edit?) -> EditorViewController {
-        return EditorViewController(settings: settings,
+        return EditorViewController(delegate: self,
+                                    settings: settings,
                                     segments: [segment],
                                     assetsHandler: assetsHandler,
                                     exporterClass: exporterClass,


### PR DESCRIPTION
In https://github.com/tumblr/kanvas-ios/pull/122 we tried to move calls to `EditorView.setupViews` until later in the view cycle in order to ensure the `delegate` property was set so that methods like `getQuickPostButton` would be available at the appropriate time.

This caused some unintended side effects for view set up and produced a blank screen for the editor.

Instead, we'll revert to an older iteration where the delegate is passed it at initialization time to ensure it exists before the existing `setupViews` call is made.