### PR TITLE
Add filter type change from Tumblr app

### DIFF
--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -884,6 +884,7 @@ public final class EditorViewController: UIViewController, MediaPlayerController
 
     private func createFinalVideo(videoURL: URL, mediaInfo: MediaInfo, archive: Data, exportAction: KanvasExportAction) {
         let exporter = exporterClass.init(settings: settings)
+        exporter.filterType = filterType ?? .passthrough
         exporter.imageOverlays = imageOverlays()
         exporter.export(video: videoURL, mediaInfo: mediaInfo, toSize: exportSize) { (exportedVideoURL, error) in
             performUIUpdate {


### PR DESCRIPTION
This sets the filter type used when exporting video. I think there was a bad merge somewhere and this got dropped from the file.

### Testing
- Select a video from the photo library
- Apply a filter to that video
- Ensure that the filter is applied