### PR TITLE
Update FBSnapshot Library

### DIFF
--- a/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
+++ b/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0EDE7A3B216425BD009DB00F /* ExtendedStackViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE7A3A216425BD009DB00F /* ExtendedStackViewTests.swift */; };
 		0EDE7A3D216425C5009DB00F /* ExtendedButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE7A3C216425C5009DB00F /* ExtendedButtonTests.swift */; };
 		1F11FE1FF570F16AE42DE1EB /* libPods-KanvasExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4E3D4DAD54900431C164FE1 /* libPods-KanvasExampleTests.a */; };
+		5E1399DE40FDDBD3F12B4468 /* Pods_KanvasExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FBD328E5F4D4ECEBA5561F5 /* Pods_KanvasExampleTests.framework */; };
 		650648012478291B0052C175 /* SpeedControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650648002478291B0052C175 /* SpeedControllerTests.swift */; };
 		65064803247829270052C175 /* SpeedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65064802247829270052C175 /* SpeedViewTests.swift */; };
 		650A833F24646A350071BF9D /* GifMakerControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650A833E24646A350071BF9D /* GifMakerControllerTests.swift */; };
@@ -246,6 +247,7 @@
 		0EDE7A3A216425BD009DB00F /* ExtendedStackViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedStackViewTests.swift; sourceTree = "<group>"; };
 		0EDE7A3C216425C5009DB00F /* ExtendedButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedButtonTests.swift; sourceTree = "<group>"; };
 		2E2C11793C82F53D672DCC9A /* Pods-KanvasExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KanvasExample.release.xcconfig"; path = "Target Support Files/Pods-KanvasExample/Pods-KanvasExample.release.xcconfig"; sourceTree = "<group>"; };
+		2FBD328E5F4D4ECEBA5561F5 /* Pods_KanvasExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KanvasExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		528EA69F8E77F28A567AEDBC /* Pods-KanvasExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KanvasExample.debug.xcconfig"; path = "Target Support Files/Pods-KanvasExample/Pods-KanvasExample.debug.xcconfig"; sourceTree = "<group>"; };
 		650648002478291B0052C175 /* SpeedControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedControllerTests.swift; sourceTree = "<group>"; };
 		65064802247829270052C175 /* SpeedViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedViewTests.swift; sourceTree = "<group>"; };
@@ -424,7 +426,6 @@
 		BFA7DAA724E3BA8000F357B6 /* LivePhotoLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoLoaderTests.swift; sourceTree = "<group>"; };
 		BFA7DAA924E3BACE00F357B6 /* MediaPickerThumbnailFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickerThumbnailFetcherTests.swift; sourceTree = "<group>"; };
 		BFA7DAAB24E42A9000F357B6 /* KanvasMediaPickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KanvasMediaPickerViewControllerTests.swift; sourceTree = "<group>"; };
-		E4E3D4DAD54900431C164FE1 /* libPods-KanvasExampleTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KanvasExampleTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F551187F25DDC96700DEBF7E /* MultiEditorControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultiEditorControllerTests.swift; sourceTree = "<group>"; };
 		F58D37B925117A88007CDF82 /* en.lproj */ = {isa = PBXFileReference; lastKnownFileType = folder; path = en.lproj; sourceTree = "<group>"; };
 		F597B4E024B3E57300843540 /* UIColor+Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Colors.swift"; sourceTree = "<group>"; };
@@ -449,7 +450,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1F11FE1FF570F16AE42DE1EB /* libPods-KanvasExampleTests.a in Frameworks */,
+				5E1399DE40FDDBD3F12B4468 /* Pods_KanvasExampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -493,7 +494,7 @@
 			isa = PBXGroup;
 			children = (
 				973CC439A84BFDE7FC10BAC1 /* libPods-KanvasExample.a */,
-				E4E3D4DAD54900431C164FE1 /* libPods-KanvasExampleTests.a */,
+				2FBD328E5F4D4ECEBA5561F5 /* Pods_KanvasExampleTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -1147,6 +1148,7 @@
 				AB7F29582121F0ED00B8D599 /* Sources */,
 				AB7F29592121F0ED00B8D599 /* Frameworks */,
 				AB7F295A2121F0ED00B8D599 /* Resources */,
+				DE95F59B62017B241AAF5CD5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1284,6 +1286,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DE95F59B62017B241AAF5CD5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-KanvasExampleTests/Pods-KanvasExampleTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-KanvasExampleTests/Pods-KanvasExampleTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-KanvasExampleTests/Pods-KanvasExampleTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
@@ -63,7 +63,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
     func testSetUpWithAllOptionsAndModesShouldStartWithFlashOffAndStopMotionMode() {
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetupWithStopMotionDisabled() {
@@ -72,7 +72,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = false
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetUpWithGifDefaultModeShouldStartWithGifMode() {
@@ -82,7 +82,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetUpWithFlashOn() {
@@ -92,7 +92,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testSetUpWithImagePreviewOn() {
@@ -102,7 +102,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnPhotoMode() {
@@ -111,7 +111,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.photo, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnStopMotionMode() {
@@ -120,7 +120,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.stopMotion, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnGifMode() {
@@ -129,7 +129,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.loop, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // Can't test `exportStopMotionPhotoAsVideo` because it can't export in tests
@@ -147,7 +147,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didOpenMode(.stopMotion, andClosed: .none)
         controller.didTapForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testStartLongPressShouldHideUIButFilterSelectorAndShutterButton() {
@@ -168,7 +168,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didStartPressingForMode(.stopMotion)
         controller.didEndPressingForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testTapAndLongPressShouldAddTwoClipsAndShowNextButton() {
@@ -180,7 +180,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didStartPressingForMode(.stopMotion)
         controller.didEndPressingForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // MARK: - CameraViewDelegate
@@ -293,7 +293,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didTapVisibilityButton(visible: true)
         controller.didTapVisibilityButton(visible: false)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // Can't test `dismissButtonPressed` because it requires presenting and dismissing preview controller.

--- a/KanvasExample/KanvasExampleTests/Camera/CameraPermissionsTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraPermissionsTests.swift
@@ -133,31 +133,31 @@ final class CameraPermissionsViewTests: FBSnapshotTestCase {
     func testViewWithNoAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.layoutIfNeeded()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithCameraAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateCameraAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithMicrophoneAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateMicrophoneAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithCameraAndMicrophoneAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateCameraAccess(hasAccess: true)
         view.updateMicrophoneAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithoutMediaPickerButton() {
         let view = CameraPermissionsView(showMediaPicker: false, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionCellTests.swift
@@ -28,6 +28,6 @@ final class CameraFilterCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionControllerTests.swift
@@ -30,6 +30,6 @@ final class CameraFilterCollectionControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionViewTests.swift
@@ -50,7 +50,7 @@ final class CameraFilterCollectionViewTests: FBSnapshotTestCase, UICollectionVie
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsControllerTests.swift
@@ -39,6 +39,6 @@ final class FilterSettingsControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didTapVisibilityButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Constants/KanvasFontsTests.swift
+++ b/KanvasExample/KanvasExampleTests/Constants/KanvasFontsTests.swift
@@ -18,14 +18,14 @@ class KanvasFontsTests: FBSnapshotTestCase {
         let label = newLabelView()
         let drawer = KanvasFonts.Drawer(textSelectedFont: .guavaMedium(), textUnselectedFont: .guavaMedium())
         label.font = drawer.textSelectedFont
-        FBSnapshotVerifyView(label, tolerance: 0.05)
+        FBSnapshotVerifyView(label, overallTolerance: 0.05)
     }
     
     func testPermissionsFont() {
         let label = newLabelView()
         let permissions = KanvasFonts.CameraPermissions(titleFont: .guavaMedium(), descriptionFont: .guavaMedium(), buttonFont: .guavaMedium())
         label.font = permissions.titleFont
-        FBSnapshotVerifyView(label, tolerance: 0.05)
+        FBSnapshotVerifyView(label, overallTolerance: 0.05)
     }
     
     func testPadding() {

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingControllerTests.swift
@@ -31,6 +31,6 @@ final class DrawingControllerTests: FBSnapshotTestCase {
         controller.showView(true)
         controller.showConfirmButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorControllerTests.swift
@@ -29,6 +29,6 @@ final class StrokeSelectorControllerTests: FBSnapshotTestCase {
     
     func testSelectorControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorViewTests.swift
@@ -29,6 +29,6 @@ final class StrokeSelectorViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionCellTests.swift
@@ -28,6 +28,6 @@ final class EditorFilterCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionViewTests.swift
@@ -50,7 +50,7 @@ final class EditorFilterCollectionViewTests: FBSnapshotTestCase, UICollectionVie
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerControllerTests.swift
@@ -31,6 +31,6 @@ final class GifMakerControllerTests: FBSnapshotTestCase {
         controller.showView(true)
         controller.showConfirmButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerViewTests.swift
@@ -27,13 +27,13 @@ final class GifMakerViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.showConfirmButton(true)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     func testRevertButton() {
         let view = newView()
         view.toggleRevertButton(true)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderCollectionCellTests.swift
@@ -82,6 +82,6 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: true, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: false, rightLineActive: false)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderTests.swift
@@ -29,6 +29,6 @@ final class DiscreteSliderTests: FBSnapshotTestCase {
     
     func testSliderView() {
         let slider = newSlider()
-        FBSnapshotVerifyView(slider.view, tolerance: 0.05)
+        FBSnapshotVerifyView(slider.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderViewTests.swift
@@ -29,20 +29,20 @@ final class DiscreteSliderViewTests: FBSnapshotTestCase {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 0)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     func testViewSetupWithIndex() {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 2)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     func testViewSetupAtLastPosition() {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 4)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedControllerTests.swift
@@ -30,6 +30,6 @@ final class SpeedControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedViewTests.swift
@@ -27,6 +27,6 @@ final class SpeedViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.setLabelText("1x")
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TimeIndicatorTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TimeIndicatorTests.swift
@@ -27,7 +27,7 @@ final class TimeIndicatorTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.text = "0:02"
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerControllerTests.swift
@@ -27,6 +27,6 @@ final class MediaDrawerControllerTests: FBSnapshotTestCase {
     
     func testMediaDrawerControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuCellTests.swift
@@ -29,6 +29,6 @@ final class StyleMenuCellTests: FBSnapshotTestCase {
         let editionOption = EditionOption.media
         cell.bindTo(editionOption, enabled: false)
         cell.layoutIfNeeded()
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuControllerTests.swift
@@ -35,6 +35,6 @@ final class StyleMenuControllerTests: FBSnapshotTestCase {
     
     func testControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuRoundedLabelTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuRoundedLabelTests.swift
@@ -30,6 +30,6 @@ final class StyleMenuRoundedLabelTests: FBSnapshotTestCase {
         let label = newLabel()
         label.text = "Test"
         label.layoutIfNeeded()
-        FBSnapshotVerifyView(label, tolerance: 0.05)
+        FBSnapshotVerifyView(label, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuViewTests.swift
@@ -44,7 +44,7 @@ final class StyleMenuViewTests: FBSnapshotTestCase, StyleMenuViewDelegate {
         view.load()
         view.setNeedsLayout()
         view.expandCollection()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     // MARK: - StyleMenuViewDelegate

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerControllerTests.swift
@@ -29,6 +29,6 @@ final class ColorPickerControllerTests: FBSnapshotTestCase {
     
     func testSelectorControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerViewTests.swift
@@ -29,6 +29,6 @@ final class ColorPickerViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Extensions/UIImage+PixelBufferTests.swift
+++ b/KanvasExample/KanvasExampleTests/Extensions/UIImage+PixelBufferTests.swift
@@ -38,6 +38,6 @@ final class UIImagePixelBufferTests: FBSnapshotTestCase {
         let newUIImage = UIImage(pixelBuffer: pixelBuffer)
         let imageView = UIImageView(image: newUIImage)
         imageView.add(into: view)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Filters/FilterCollectionInnerCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Filters/FilterCollectionInnerCellTests.swift
@@ -39,6 +39,6 @@ final class FilterCollectionInnerCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Filters/FilterCollectionTests.swift
+++ b/KanvasExample/KanvasExampleTests/Filters/FilterCollectionTests.swift
@@ -61,7 +61,7 @@ final class FilterCollectionTests: FBSnapshotTestCase, UICollectionViewDelegate,
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.reloadData()
-        FBSnapshotVerifyView(collectionView, tolerance: 0.05)
+        FBSnapshotVerifyView(collectionView, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionCellTests.swift
@@ -35,7 +35,7 @@ final class MediaClipsCollectionCellTests: FBSnapshotTestCase {
         }
 
         cell.bindTo(clip)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeButtonViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeButtonViewTests.swift
@@ -29,7 +29,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .photo))
-        FBSnapshotVerifyView(modeButton, tolerance: 0.05)
+        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
     
@@ -39,7 +39,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .loop))
-        FBSnapshotVerifyView(modeButton, tolerance: 0.05)
+        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
 
@@ -49,7 +49,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .stopMotion))
-        FBSnapshotVerifyView(modeButton, tolerance: 0.05)
+        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
 }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootControllerTests.swift
@@ -34,7 +34,7 @@ final class ModeSelectorAndShootControllerTests: FBSnapshotTestCase {
     func testShowMode() {
         let viewController = newViewController()
         viewController.showModeButton()
-        FBSnapshotVerifyView(viewController.view, tolerance: 0.05)
+        FBSnapshotVerifyView(viewController.view, overallTolerance: 0.05)
     }
 
     func testHideMode() {
@@ -48,7 +48,7 @@ final class ModeSelectorAndShootControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.setMode(.stopMotion, from: .loop)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view, tolerance: 0.05)
+        FBSnapshotVerifyView(viewController.view, overallTolerance: 0.05)
     }
 
     func testModeTap() {

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootViewTests.swift
@@ -27,19 +27,19 @@ final class ModeSelectorAndShootViewTests: FBSnapshotTestCase {
     func testPhotoMode() {
         let view = newView()
         view.setUpMode(.photo)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testGifMode() {
         let view = newView()
         view.setUpMode(.loop)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testStopMotionMode() {
         let view = newView()
         view.setUpMode(.stopMotion)
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
 
     func testShowModeButton() {

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorCellTests.swift
@@ -27,13 +27,13 @@ final class OptionSelectorCellTests: FBSnapshotTestCase {
     func testCell() {
         let cell = newCell()
         cell.bindTo(PlaybackOption.loop)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
     
     func testSelectedCell() {
         let cell = newCell()
         cell.bindTo(PlaybackOption.loop)
         cell.setSelected(true, animated: false)
-        FBSnapshotVerifyView(cell, tolerance: 0.05)
+        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorControllerTests.swift
@@ -29,6 +29,6 @@ final class OptionSelectorControllerTests: FBSnapshotTestCase {
     
     func testControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, tolerance: 0.05)
+        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorViewTests.swift
@@ -35,7 +35,7 @@ final class OptionSelectorViewTests: FBSnapshotTestCase, UICollectionViewDataSou
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, tolerance: 0.05)
+        FBSnapshotVerifyView(view, overallTolerance: 0.05)
     }
     
     // MARK: - UICollectionViewDataSource

--- a/KanvasExample/Podfile
+++ b/KanvasExample/Podfile
@@ -10,6 +10,7 @@ target 'KanvasExample' do
     
     target 'KanvasExampleTests' do
         inherit! :search_paths
-        pod 'FBSnapshotTestCase', '2.1.4'
+	use_frameworks!
+        pod 'iOSSnapshotTestCase', '8.0.0'
     end
 end

--- a/KanvasExample/Podfile.lock
+++ b/KanvasExample/Podfile.lock
@@ -1,27 +1,27 @@
 PODS:
-  - FBSnapshotTestCase (2.1.4):
-    - FBSnapshotTestCase/SwiftSupport (= 2.1.4)
-  - FBSnapshotTestCase/Core (2.1.4)
-  - FBSnapshotTestCase/SwiftSupport (2.1.4):
-    - FBSnapshotTestCase/Core
+  - iOSSnapshotTestCase (8.0.0):
+    - iOSSnapshotTestCase/SwiftSupport (= 8.0.0)
+  - iOSSnapshotTestCase/Core (8.0.0)
+  - iOSSnapshotTestCase/SwiftSupport (8.0.0):
+    - iOSSnapshotTestCase/Core
   - Kanvas (1.3.5)
 
 DEPENDENCIES:
-  - FBSnapshotTestCase (= 2.1.4)
+  - iOSSnapshotTestCase (= 8.0.0)
   - Kanvas (from `../`)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
-    - FBSnapshotTestCase
+    - iOSSnapshotTestCase
 
 EXTERNAL SOURCES:
   Kanvas:
     :path: "../"
 
 SPEC CHECKSUMS:
-  FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
+  iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   Kanvas: 55d9c3606495cd58a8586d1df018f77656543f5a
 
-PODFILE CHECKSUM: 14b28dd726149c0d01dba9154d5bb095d9ba6a18
+PODFILE CHECKSUM: 6056b6f4c65b8326861b9cb6120a717bc03a9d4d
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
FBSnapshotTestCase was renamed to iOSSnapshotTestCase and we've updated from v 2 to 8.0.0

This update includes functionality to deal with M1 & intel snapshot difference issues and ViewController snapshot convenience methods.