### PR TITLE
Make snapshot tests M1 compatible

### DIFF
--- a/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
+++ b/KanvasExample/KanvasExample.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		0EBE144E2123727800E9D0C8 /* CameraSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBE144D2123727800E9D0C8 /* CameraSettingsTests.swift */; };
 		0EDE7A3B216425BD009DB00F /* ExtendedStackViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE7A3A216425BD009DB00F /* ExtendedStackViewTests.swift */; };
 		0EDE7A3D216425C5009DB00F /* ExtendedButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDE7A3C216425C5009DB00F /* ExtendedButtonTests.swift */; };
-		1F11FE1FF570F16AE42DE1EB /* libPods-KanvasExampleTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E4E3D4DAD54900431C164FE1 /* libPods-KanvasExampleTests.a */; };
+		1431FA3B2812DD52007BA9B6 /* FBSnapshotTest+M1Compatability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1431FA3A2812DD52007BA9B6 /* FBSnapshotTest+M1Compatability.swift */; };
 		5E1399DE40FDDBD3F12B4468 /* Pods_KanvasExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FBD328E5F4D4ECEBA5561F5 /* Pods_KanvasExampleTests.framework */; };
 		650648012478291B0052C175 /* SpeedControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650648002478291B0052C175 /* SpeedControllerTests.swift */; };
 		65064803247829270052C175 /* SpeedViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65064802247829270052C175 /* SpeedViewTests.swift */; };
@@ -246,6 +246,7 @@
 		0EBE144D2123727800E9D0C8 /* CameraSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraSettingsTests.swift; sourceTree = "<group>"; };
 		0EDE7A3A216425BD009DB00F /* ExtendedStackViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedStackViewTests.swift; sourceTree = "<group>"; };
 		0EDE7A3C216425C5009DB00F /* ExtendedButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendedButtonTests.swift; sourceTree = "<group>"; };
+		1431FA3A2812DD52007BA9B6 /* FBSnapshotTest+M1Compatability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FBSnapshotTest+M1Compatability.swift"; sourceTree = "<group>"; };
 		2E2C11793C82F53D672DCC9A /* Pods-KanvasExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KanvasExample.release.xcconfig"; path = "Target Support Files/Pods-KanvasExample/Pods-KanvasExample.release.xcconfig"; sourceTree = "<group>"; };
 		2FBD328E5F4D4ECEBA5561F5 /* Pods_KanvasExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KanvasExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		528EA69F8E77F28A567AEDBC /* Pods-KanvasExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KanvasExample.debug.xcconfig"; path = "Target Support Files/Pods-KanvasExample/Pods-KanvasExample.debug.xcconfig"; sourceTree = "<group>"; };
@@ -488,6 +489,14 @@
 				0EBE144D2123727800E9D0C8 /* CameraSettingsTests.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		1431FA392812DD2C007BA9B6 /* TestHelpers */ = {
+			isa = PBXGroup;
+			children = (
+				1431FA3A2812DD52007BA9B6 /* FBSnapshotTest+M1Compatability.swift */,
+			);
+			path = TestHelpers;
 			sourceTree = "<group>";
 		};
 		207DC35FB9695882309558B9 /* Frameworks */ = {
@@ -980,6 +989,7 @@
 		AB7F295D2121F0ED00B8D599 /* KanvasExampleTests */ = {
 			isa = PBXGroup;
 			children = (
+				1431FA392812DD2C007BA9B6 /* TestHelpers */,
 				F5E448C924B8E23000403A7C /* KanvasCustomUITests.swift */,
 				0EAE0CB72139EC81004CD7FF /* KanvasAnalyticsStub.swift */,
 				0EAE0CAE2139B966004CD7FF /* CameraPreview */,
@@ -1398,6 +1408,7 @@
 				658A32A3239FFD9B00EEC1D3 /* MediaDrawerControllerTests.swift in Sources */,
 				6539F18E255C30DB00FCCA22 /* KanvasEditorDesignTests.swift in Sources */,
 				655C934F234CCA80008F26AF /* ColorSelectorViewTests.swift in Sources */,
+				1431FA3B2812DD52007BA9B6 /* FBSnapshotTest+M1Compatability.swift in Sources */,
 				6578F83B22E12098002B952C /* ColorThiefTests.swift in Sources */,
 				65E46BA922BD22DE004FD226 /* EditorControllerTests.swift in Sources */,
 				F597B50B24B5017B00843540 /* MediaInfoTests.swift in Sources */,

--- a/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraControllerTests.swift
@@ -63,7 +63,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
     func testSetUpWithAllOptionsAndModesShouldStartWithFlashOffAndStopMotionMode() {
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetupWithStopMotionDisabled() {
@@ -72,7 +72,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = false
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetUpWithGifDefaultModeShouldStartWithGifMode() {
@@ -82,7 +82,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testSetUpWithFlashOn() {
@@ -92,7 +92,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testSetUpWithImagePreviewOn() {
@@ -102,7 +102,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.ghostFrame = true
         settings.features.cameraFilters = true
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnPhotoMode() {
@@ -111,7 +111,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.photo, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnStopMotionMode() {
@@ -120,7 +120,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.stopMotion, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
     
     func testImagePreviewButtonShouldHideOnGifMode() {
@@ -129,7 +129,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didOpenMode(.loop, andClosed: .none)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // Can't test `exportStopMotionPhotoAsVideo` because it can't export in tests
@@ -147,7 +147,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didOpenMode(.stopMotion, andClosed: .none)
         controller.didTapForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testStartLongPressShouldHideUIButFilterSelectorAndShutterButton() {
@@ -157,7 +157,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didOpenMode(.stopMotion, andClosed: .none)
         controller.didStartPressingForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testEndLongPressShouldHideModeButtonAndAddClipAndShowNextButtons() {
@@ -168,7 +168,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didStartPressingForMode(.stopMotion)
         controller.didEndPressingForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     func testTapAndLongPressShouldAddTwoClipsAndShowNextButton() {
@@ -180,7 +180,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didStartPressingForMode(.stopMotion)
         controller.didEndPressingForMode(.stopMotion)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // MARK: - CameraViewDelegate
@@ -226,7 +226,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.cameraFilters = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraWithMediaPickerButton() {
@@ -236,7 +236,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.cameraFilters = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraWithFiltersOpenHidesMediaPickerButton() {
@@ -249,7 +249,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didTapVisibilityButton(visible: true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraInNormalModeShowsMediaPickerButton() {
@@ -259,7 +259,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.cameraFilters = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraInStitchModeDoesNotShowMediaPickerButton() {
@@ -269,7 +269,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.cameraFilters = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraInGIFModeDoesNotShowMediaPickerButton() {
@@ -279,7 +279,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.features.cameraFilters = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testCameraClosingFiltersInStitchModeDoesNotShowMediaPickerAgain() {
@@ -293,7 +293,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         controller.didTapVisibilityButton(visible: true)
         controller.didTapVisibilityButton(visible: false)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 
     // Can't test `dismissButtonPressed` because it requires presenting and dismissing preview controller.
@@ -304,7 +304,7 @@ final class CameraControllerTests: FBSnapshotTestCase {
         settings.topButtonsSwapped = true
         let delegate = newDelegateStub()
         let controller = newController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }
 

--- a/KanvasExample/KanvasExampleTests/Camera/CameraPermissionsTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraPermissionsTests.swift
@@ -133,31 +133,31 @@ final class CameraPermissionsViewTests: FBSnapshotTestCase {
     func testViewWithNoAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.layoutIfNeeded()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithCameraAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateCameraAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithMicrophoneAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateMicrophoneAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithCameraAndMicrophoneAccess() {
         let view = CameraPermissionsView(showMediaPicker: true, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         view.updateCameraAccess(hasAccess: true)
         view.updateMicrophoneAccess(hasAccess: true)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testViewWithoutMediaPickerButton() {
         let view = CameraPermissionsView(showMediaPicker: false, frame: CGRect(x: 0, y: 0, width: 375, height: 667))
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Camera/CameraViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/CameraViewTests.swift
@@ -27,7 +27,7 @@ final class CameraViewTests: FBSnapshotTestCase {
 
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testUpdateUIForRecording() {
@@ -35,7 +35,7 @@ final class CameraViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.updateUI(forRecording: true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testUpdateUIForNotRecording() {
@@ -44,7 +44,7 @@ final class CameraViewTests: FBSnapshotTestCase {
         view.updateUI(forRecording: true)
         view.updateUI(forRecording: false)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Camera/FilteredInputViewControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/FilteredInputViewControllerTests.swift
@@ -30,7 +30,7 @@ final class FilteredInputViewControllerTests: FBSnapshotTestCase {
         let delegate = FilteredInputViewControllerDelegateStub()
         let settings = CameraSettings()
         let controller = FilteredInputViewController(delegate: delegate, settings: settings)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionCellTests.swift
@@ -28,6 +28,6 @@ final class CameraFilterCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionControllerTests.swift
@@ -30,6 +30,6 @@ final class CameraFilterCollectionControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/CameraFilterCollectionViewTests.swift
@@ -50,7 +50,7 @@ final class CameraFilterCollectionViewTests: FBSnapshotTestCase, UICollectionVie
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsControllerTests.swift
@@ -31,7 +31,7 @@ final class FilterSettingsControllerTests: FBSnapshotTestCase {
         controller.didTapVisibilityButton()
         controller.didTapVisibilityButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 
     func testShowCollection() {
@@ -39,6 +39,6 @@ final class FilterSettingsControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.didTapVisibilityButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/Filters/FilterSettingsViewTests.swift
@@ -26,6 +26,6 @@ final class FilterSettingsViewTests: FBSnapshotTestCase {
     
     func testIcon() {
         let settingsView = newSettingsView()
-        FBSnapshotVerifyView(settingsView)
+        FBSnapshotArchFriendlyVerifyView(settingsView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Camera/ImagePreviewControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Camera/ImagePreviewControllerTests.swift
@@ -29,7 +29,7 @@ final class ImagePreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showImagePreview(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
     
     func testSetImagePreview() {
@@ -37,7 +37,7 @@ final class ImagePreviewControllerTests: FBSnapshotTestCase {
         controller.showImagePreview(true)
         controller.setImagePreview(testImage)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
     
     func testSetImagePreviewWithNil() {
@@ -45,7 +45,7 @@ final class ImagePreviewControllerTests: FBSnapshotTestCase {
         controller.showImagePreview(true)
         controller.setImagePreview(nil)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
     
     func testSetImagePreviewOff() {
@@ -53,7 +53,7 @@ final class ImagePreviewControllerTests: FBSnapshotTestCase {
         controller.showImagePreview(false)
         controller.setImagePreview(testImage)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
     
     func testSetImagePreviewTwice() {
@@ -62,6 +62,6 @@ final class ImagePreviewControllerTests: FBSnapshotTestCase {
         controller.setImagePreview(testImage)
         controller.setImagePreview(secondTestImage)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/CameraPreview/CameraPreviewControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/CameraPreview/CameraPreviewControllerTests.swift
@@ -86,7 +86,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
     func testSetUp() {
         let segments = getAllSegments()
         let viewController = newViewController(segments: segments)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testShowLoading() {
@@ -96,7 +96,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         viewController.hideLoading()
         viewController.showLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testHideLoading() {
@@ -106,7 +106,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         viewController.showLoading()
         viewController.hideLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testConfirmPhoto() {
@@ -117,7 +117,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.confirmButtonPressed()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(!handler.mergeAssetsCalled, "Handler merge assets function called")
         XCTAssert(delegate.imageExportCalled, "Delegate image export function not called")
     }
@@ -130,7 +130,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.confirmButtonPressed()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         XCTAssert(delegate.videoExportCalled, "Delegate video export function not called")
     }
@@ -168,7 +168,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.confirmButtonPressed()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         XCTAssert(delegate.videoExportCalled, "Delegate video export function not called")
     }
@@ -181,7 +181,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.confirmButtonPressed()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         XCTAssert(delegate.videoExportCalled, "Delegate video export function not called")
     }
@@ -193,7 +193,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.closeButtonPressed()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(delegate.closeCalled, "Delegate close function not called")
     }
 

--- a/KanvasExample/KanvasExampleTests/CameraPreview/CameraPreviewViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/CameraPreview/CameraPreviewViewTests.swift
@@ -35,21 +35,21 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
 
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testSetFirstPlayer() {
         let view = newView()
         let player = newPlayer()
         view.setFirstPlayer(player: player)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testSetSecondPlayer() {
         let view = newView()
         let player = newPlayer()
         view.setSecondPlayer(player: player)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testSetImage() {
@@ -58,7 +58,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
             UIView.setAnimationsEnabled(false)
             view.setImage(image: image)
             UIView.setAnimationsEnabled(true)
-            FBSnapshotVerifyView(view)
+            FBSnapshotArchFriendlyVerifyView(view)
         }
     }
 
@@ -69,7 +69,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.showFirstPlayer()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testShowSecondPlayer() {
@@ -79,7 +79,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.showSecondPlayer()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testShowSecondPlayerAfterFirstPlayer() {
@@ -92,7 +92,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
         view.showFirstPlayer()
         view.showSecondPlayer()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testShowFirstPlayerAfterSecondPlayer() {
@@ -105,7 +105,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
         view.showSecondPlayer()
         view.showFirstPlayer()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testShowImageAfterFirstPlayer() {
@@ -117,7 +117,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
             view.showFirstPlayer()
             view.setImage(image: image)
             UIView.setAnimationsEnabled(true)
-            FBSnapshotVerifyView(view)
+            FBSnapshotArchFriendlyVerifyView(view)
         }
     }
 
@@ -130,7 +130,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
             view.setImage(image: image)
             view.showFirstPlayer()
             UIView.setAnimationsEnabled(true)
-            FBSnapshotVerifyView(view)
+            FBSnapshotArchFriendlyVerifyView(view)
         }
     }
 
@@ -143,7 +143,7 @@ final class CameraPreviewViewTests: FBSnapshotTestCase {
             view.setImage(image: image)
             view.showSecondPlayer()
             UIView.setAnimationsEnabled(true)
-            FBSnapshotVerifyView(view)
+            FBSnapshotArchFriendlyVerifyView(view)
         }
     }
 

--- a/KanvasExample/KanvasExampleTests/Constants/KanvasColorsTests.swift
+++ b/KanvasExample/KanvasExampleTests/Constants/KanvasColorsTests.swift
@@ -17,6 +17,6 @@ final class KanvasColorsTests: FBSnapshotTestCase {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
         view.backgroundColor = KanvasColors.shared.shootButtonBaseColor
         
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Constants/KanvasFontsTests.swift
+++ b/KanvasExample/KanvasExampleTests/Constants/KanvasFontsTests.swift
@@ -18,14 +18,14 @@ class KanvasFontsTests: FBSnapshotTestCase {
         let label = newLabelView()
         let drawer = KanvasFonts.Drawer(textSelectedFont: .guavaMedium(), textUnselectedFont: .guavaMedium())
         label.font = drawer.textSelectedFont
-        FBSnapshotVerifyView(label, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(label, overallTolerance: 0.05)
     }
     
     func testPermissionsFont() {
         let label = newLabelView()
         let permissions = KanvasFonts.CameraPermissions(titleFont: .guavaMedium(), descriptionFont: .guavaMedium(), buttonFont: .guavaMedium())
         label.font = permissions.titleFont
-        FBSnapshotVerifyView(label, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(label, overallTolerance: 0.05)
     }
     
     func testPadding() {

--- a/KanvasExample/KanvasExampleTests/Constants/KanvasImagesTests.swift
+++ b/KanvasExample/KanvasExampleTests/Constants/KanvasImagesTests.swift
@@ -21,7 +21,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.photoModeImage
         /// photo image can be nil.
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testStopMotionModeImage() {
@@ -29,7 +29,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.stopMotionModeImage
         /// stop motion image can be nil.
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testFlashOnImage() {
@@ -37,7 +37,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.flashOnImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testFlashOffImage() {
@@ -45,7 +45,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.flashOffImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testCameraPositionImage() {
@@ -53,7 +53,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.cameraPositionImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testCloseImage() {
@@ -61,7 +61,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.closeImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testConfirmImage() {
@@ -69,7 +69,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.shared.confirmImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func testBackImage() {
@@ -77,7 +77,7 @@ final class KanvasImagesTests: FBSnapshotTestCase {
         let image = KanvasImages.backImage
         XCTAssert(image != nil, "Image not found")
         imageView.image = image
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 
     func newImageView() -> UIImageView {

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingControllerTests.swift
@@ -31,6 +31,6 @@ final class DrawingControllerTests: FBSnapshotTestCase {
         controller.showView(true)
         controller.showConfirmButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/DrawingViewTests.swift
@@ -28,7 +28,7 @@ final class DrawingViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.showConfirmButton(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     // Cannot test DrawingCanvas since touchesBegan cannot be called programmatically
@@ -38,6 +38,6 @@ final class DrawingViewTests: FBSnapshotTestCase {
         let drawingCanvas = DrawingCanvas()
         drawingCanvas.backgroundColor = .blue
         drawingCanvas.add(into: view)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorControllerTests.swift
@@ -29,6 +29,6 @@ final class StrokeSelectorControllerTests: FBSnapshotTestCase {
     
     func testSelectorControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/StrokeSelector/StrokeSelectorViewTests.swift
@@ -29,6 +29,6 @@ final class StrokeSelectorViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/TextureSelector/TextureSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/TextureSelector/TextureSelectorControllerTests.swift
@@ -29,6 +29,6 @@ final class TextureSelectorControllerTests: FBSnapshotTestCase {
     
     func testSelectorControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/TextureSelector/TextureSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/TextureSelector/TextureSelectorViewTests.swift
@@ -29,6 +29,6 @@ final class TextureSelectorViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/MarkerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/MarkerTests.swift
@@ -43,7 +43,7 @@ final class MarkerTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
     func testDrawingLine() {
@@ -64,6 +64,6 @@ final class MarkerTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/PencilTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/PencilTests.swift
@@ -44,7 +44,7 @@ final class PencilTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
     func testDrawingLine() {
@@ -65,6 +65,6 @@ final class PencilTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/RoundedTextureTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/RoundedTextureTests.swift
@@ -43,7 +43,7 @@ final class RoundedTextureTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
     func testDrawingLine() {
@@ -64,6 +64,6 @@ final class RoundedTextureTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/SharpieTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Drawing/Textures/SharpieTests.swift
@@ -43,7 +43,7 @@ final class SharpieTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
     func testDrawingLine() {
@@ -64,6 +64,6 @@ final class SharpieTests: FBSnapshotTestCase {
         }
         UIGraphicsEndImageContext()
         
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorControllerTests.swift
@@ -156,7 +156,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
     func testSetUp() {
         let segments = getAllSegments()
         let viewController = newViewController(segments: segments)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
     
     func testShowLoading() {
@@ -166,7 +166,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         viewController.hideLoading()
         viewController.showLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
     
     func testHideLoading() {
@@ -176,7 +176,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         viewController.showLoading()
         viewController.hideLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
     
     func testConfirmPhoto() {
@@ -188,7 +188,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapConfirmButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(!handler.mergeAssetsCalled, "Handler merge assets function called")
         XCTAssert(delegate.imageExportCalled, "Delegate image export function not called")
     }
@@ -202,7 +202,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapConfirmButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(!handler.mergeAssetsCalled, "Handler merge assets function not called")
         XCTAssert(delegate.framesExportCalled, "Delegate frames export function not called")
     }
@@ -254,7 +254,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapConfirmButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         wait(for: [expectation], timeout: 2)
         XCTAssert(delegate.videoExportCalled, "Delegate video export function not called")
@@ -272,7 +272,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapConfirmButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         wait(for: [expectation], timeout: 2)
         XCTAssert(delegate.exportFailedCalled, "Delegate export failed not called")
@@ -290,7 +290,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapConfirmButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(handler.mergeAssetsCalled, "Handler merge assets function not called")
         wait(for: [expectation], timeout: 2)
         XCTAssert(delegate.videoExportCalled, "Delegate video export function not called")
@@ -303,7 +303,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didTapCloseButton()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         XCTAssert(delegate.closeCalled, "Delegate close function not called")
     }
     
@@ -313,7 +313,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         let segments = getPhotoSegment()
         let delegate = newDelegateStub()
         let viewController = newViewController(settings: settings, segments: segments, delegate: delegate)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testEditorShowsTagButton() {
@@ -322,7 +322,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         let segments = getPhotoSegment()
         let delegate = newDelegateStub()
         let viewController = newViewController(settings: settings, segments: segments, delegate: delegate)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testEditorWithFiltersOpenHidesTagButton() {
@@ -334,7 +334,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.didSelectEditionOption(.filter, cell: EditionMenuCollectionCell())
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testEditorWhenClosingFiltersShowsTagButton() {
@@ -347,7 +347,7 @@ final class EditorControllerTests: FBSnapshotTestCase {
         viewController.didSelectEditionOption(.filter, cell: EditionMenuCollectionCell())
         viewController.didConfirmFilters()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 }
 

--- a/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/EditorViewTests.swift
@@ -44,7 +44,7 @@ final class EditorViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testFullViewConstraints() {

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionCellTests.swift
@@ -28,6 +28,6 @@ final class EditorFilterCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionControllerTests.swift
@@ -30,6 +30,6 @@ final class EditorFilterCollectionControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterCollectionViewTests.swift
@@ -50,7 +50,7 @@ final class EditorFilterCollectionViewTests: FBSnapshotTestCase, UICollectionVie
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterControllerTests.swift
@@ -30,6 +30,6 @@ final class EditorFilterControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Filters/EditorFilterViewTests.swift
@@ -27,7 +27,7 @@ final class EditorFilterViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerControllerTests.swift
@@ -31,6 +31,6 @@ final class GifMakerControllerTests: FBSnapshotTestCase {
         controller.showView(true)
         controller.showConfirmButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/GifMakerViewTests.swift
@@ -27,13 +27,13 @@ final class GifMakerViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.showConfirmButton(true)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     func testRevertButton() {
         let view = newView()
         view.toggleRevertButton(true)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderCollectionCellTests.swift
@@ -29,7 +29,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.backgroundColor = .darkGray
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: true, isLast: false)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testEndingCell() {
@@ -37,7 +37,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.backgroundColor = .darkGray
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: false, isLast: true)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testCellWhenLeftSideIsActive() {
@@ -46,7 +46,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: true, rightLineActive: false)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testCellWhenRightSideIsActive() {
@@ -55,7 +55,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: false, rightLineActive: true)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testInactiveCellOnBothSides() {
@@ -64,7 +64,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: false, rightLineActive: false)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testActiveCellOnBothSides() {
@@ -73,7 +73,7 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: false, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: true, rightLineActive: true)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testCircle() {
@@ -82,6 +82,6 @@ final class DiscreteSliderCollectionCellTests: FBSnapshotTestCase {
         cell.bindTo(0)
         cell.setStyle(isCenter: true, isFirst: false, isLast: false)
         cell.setProgress(leftLineActive: false, rightLineActive: false)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderTests.swift
@@ -29,6 +29,6 @@ final class DiscreteSliderTests: FBSnapshotTestCase {
     
     func testSliderView() {
         let slider = newSlider()
-        FBSnapshotVerifyView(slider.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(slider.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderViewTests.swift
@@ -29,20 +29,20 @@ final class DiscreteSliderViewTests: FBSnapshotTestCase {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 0)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     func testViewSetupWithIndex() {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 2)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     func testViewSetupAtLastPosition() {
         let view = newView()
         view.cellWidth = view.bounds.width / 5
         view.setSelector(at: 4)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedControllerTests.swift
@@ -30,6 +30,6 @@ final class SpeedControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Speed/SpeedViewTests.swift
@@ -27,6 +27,6 @@ final class SpeedViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.setLabelText("1x")
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionCellTests.swift
@@ -29,6 +29,6 @@ final class ThumbnailCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         cell.backgroundColor = .black
         cell.bindTo(0)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionControllerTests.swift
@@ -26,7 +26,7 @@ final class ThumbnailCollectionControllerTests: FBSnapshotTestCase {
         controller.view.backgroundColor = .black
         controller.view.setNeedsDisplay()
         
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }
 

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionViewTests.swift
@@ -32,7 +32,7 @@ final class ThumbnailCollectionViewTests: FBSnapshotTestCase, UICollectionViewDa
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     // MARK: - UICollectionViewDataSource

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TimeIndicatorTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TimeIndicatorTests.swift
@@ -27,7 +27,7 @@ final class TimeIndicatorTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.text = "0:02"
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimAreaTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimAreaTests.swift
@@ -26,7 +26,7 @@ final class TrimAreaTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimControllerTests.swift
@@ -30,6 +30,6 @@ final class TrimControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/GIFMaker/Trim/TrimViewTests.swift
@@ -26,6 +26,6 @@ final class TrimViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerControllerTests.swift
@@ -27,6 +27,6 @@ final class MediaDrawerControllerTests: FBSnapshotTestCase {
     
     func testMediaDrawerControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/MediaDrawerViewTests.swift
@@ -27,6 +27,6 @@ final class MediaDrawerViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionCellTests.swift
@@ -30,6 +30,6 @@ final class StickerCollectionCellTests: FBSnapshotTestCase {
         let sticker = Sticker(id: "id", imageUrl: "imageUrl")
         
         cell.bindTo(sticker, type: stickerType, index: 0)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionControllerTests.swift
@@ -27,6 +27,6 @@ final class StickerCollectionControllerTests: FBSnapshotTestCase {
     
     func testStickerCollectionControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerCollection/StickerCollectionViewTests.swift
@@ -27,6 +27,6 @@ final class StickerCollectionViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerMenuControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerMenuControllerTests.swift
@@ -27,6 +27,6 @@ final class StickerMenuControllerTests: FBSnapshotTestCase {
     
     func testStickerMenuControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerMenuViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerMenuViewTests.swift
@@ -27,6 +27,6 @@ final class StickerMenuViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionCellTests.swift
@@ -29,6 +29,6 @@ final class StickerTypeCollectionCellTests: FBSnapshotTestCase {
         let stickerType = StickerType(id: "id", imageUrl: "imageUrl", stickers: [])
         
         cell.bindTo(stickerType)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionControllerTests.swift
@@ -27,6 +27,6 @@ final class StickerTypeCollectionControllerTests: FBSnapshotTestCase {
     
     func testStickerTypeCollectionControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionViewTests.swift
@@ -27,6 +27,6 @@ final class StickerTypeCollectionViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StylableImageViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/Stickers/StylableImageViewTests.swift
@@ -27,7 +27,7 @@ final class StylableImageViewTests: FBSnapshotTestCase {
         let view = newView()
         let imageView = StylableImageView(id: "id", image: KanvasImages.gradientImage)
         imageView.add(into: view)
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
     func testHitInsideShape() {

--- a/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarCell.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarCell.swift
@@ -28,6 +28,6 @@ final class DrawerTabBarCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let tabBarOption = DrawerTabBarOption.stickers
         cell.bindTo(tabBarOption)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarControllerTests.swift
@@ -27,6 +27,6 @@ final class DrawerTabBarControllerTests: FBSnapshotTestCase {
     
     func testDrawerTabBarControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Media/TabBar/DrawerTabBarViewTests.swift
@@ -27,6 +27,6 @@ final class DrawerTabBarViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionCellTests.swift
@@ -28,6 +28,6 @@ final class EditionMenuCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let editionOption = EditionOption.media
         cell.bindTo(editionOption, enabled: false)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionControllerTests.swift
@@ -38,6 +38,6 @@ final class EditionMenuCollectionControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/EditionMenu/EditionMenuCollectionViewTests.swift
@@ -38,7 +38,7 @@ final class EditionMenuCollectionViewTests: FBSnapshotTestCase, UICollectionView
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuCellTests.swift
@@ -29,6 +29,6 @@ final class StyleMenuCellTests: FBSnapshotTestCase {
         let editionOption = EditionOption.media
         cell.bindTo(editionOption, enabled: false)
         cell.layoutIfNeeded()
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuControllerTests.swift
@@ -35,6 +35,6 @@ final class StyleMenuControllerTests: FBSnapshotTestCase {
     
     func testControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuExpandCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuExpandCellTests.swift
@@ -23,7 +23,7 @@ final class StyleMenuExpandCellTests: FBSnapshotTestCase {
         cell.frame = CGRect(x: 0, y: 0, width: 120, height: StyleMenuExpandCell.height)
         cell.rotateUp()
         cell.layoutIfNeeded()
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
     
     func testClosedCell() {
@@ -31,6 +31,6 @@ final class StyleMenuExpandCellTests: FBSnapshotTestCase {
         cell.frame = CGRect(x: 0, y: 0, width: 115, height: StyleMenuExpandCell.height)
         cell.rotateDown()
         cell.layoutIfNeeded()
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuRoundedLabelTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuRoundedLabelTests.swift
@@ -30,6 +30,6 @@ final class StyleMenuRoundedLabelTests: FBSnapshotTestCase {
         let label = newLabel()
         label.text = "Test"
         label.layoutIfNeeded()
-        FBSnapshotVerifyView(label, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(label, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Menu/StyleMenu/StyleMenuViewTests.swift
@@ -36,7 +36,7 @@ final class StyleMenuViewTests: FBSnapshotTestCase, StyleMenuViewDelegate {
     func testMenuCollapsed() {
         let view = newCollectionView()
         view.load()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     func testMenuExpanded() {
@@ -44,7 +44,7 @@ final class StyleMenuViewTests: FBSnapshotTestCase, StyleMenuViewDelegate {
         view.load()
         view.setNeedsLayout()
         view.expandCollection()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     // MARK: - StyleMenuViewDelegate

--- a/KanvasExample/KanvasExampleTests/Editor/MovableViews/MovableViewCanvasTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/MovableViews/MovableViewCanvasTests.swift
@@ -33,7 +33,7 @@ final class MovableViewCanvasTests: FBSnapshotTestCase {
         let location = view.center
         let transformations =  ViewTransformations()
         view.addView(view: textView, transformations: transformations, location: location, size: view.frame.size, animated: true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     func testMovableTextView() {
@@ -47,6 +47,6 @@ final class MovableViewCanvasTests: FBSnapshotTestCase {
         movableView.frame = CGRect(x: 0, y: 0, width: 250, height: 100)
         view.addSubview(movableView)
         movableView.moveToDefinedPosition()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/CircularImageViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/CircularImageViewTests.swift
@@ -28,7 +28,7 @@ final class CircularImageViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let imageView = newCircularImageView()
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionCellTests.swift
@@ -30,6 +30,6 @@ final class ColorCollectionCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let color = UIColor.tumblrBrightBlue
         cell.bindTo(color)
-        FBSnapshotVerifyView(cell)
+        FBSnapshotArchFriendlyVerifyView(cell)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionControllerTests.swift
@@ -41,6 +41,6 @@ final class ColorCollectionControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.showView(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorCollection/ColorCollectionViewTests.swift
@@ -41,7 +41,7 @@ final class ColorCollectionViewTests: FBSnapshotTestCase, UICollectionViewDelega
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerControllerTests.swift
@@ -29,6 +29,6 @@ final class ColorPickerControllerTests: FBSnapshotTestCase {
     
     func testSelectorControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorPicker/ColorPickerViewTests.swift
@@ -29,6 +29,6 @@ final class ColorPickerViewTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorDropTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorDropTests.swift
@@ -28,7 +28,7 @@ final class ColorDropTests: FBSnapshotTestCase {
     
     func testViewSetup() {
         let imageView = newColorDrop()
-        FBSnapshotVerifyView(imageView)
+        FBSnapshotArchFriendlyVerifyView(imageView)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorSelectorControllerTests.swift
@@ -30,6 +30,6 @@ final class ColorSelectorControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         controller.show(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/ColorSelector/ColorSelectorViewTests.swift
@@ -29,7 +29,7 @@ final class ColorSelectorViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.show(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Shared/SliderViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Shared/SliderViewTests.swift
@@ -27,6 +27,6 @@ final class SliderViewTests: FBSnapshotTestCase {
     
     func testSliderView() {
         let sliderView = newSliderView()
-        FBSnapshotVerifyView(sliderView)
+        FBSnapshotArchFriendlyVerifyView(sliderView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Text/EditorTextControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Text/EditorTextControllerTests.swift
@@ -32,6 +32,6 @@ final class EditorTextControllerTests: FBSnapshotTestCase {
         controller.showView(true)
         controller.showConfirmButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(controller.view)
+        FBSnapshotArchFriendlyVerifyView(controller.view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Text/EditorTextViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Text/EditorTextViewTests.swift
@@ -29,7 +29,7 @@ final class EditorTextViewTests: FBSnapshotTestCase {
     func testViewSetup() {
         let view = newView()
         view.showConfirmButton(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
     
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Text/MainTextViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Text/MainTextViewTests.swift
@@ -31,6 +31,6 @@ final class MainTextViewTests: FBSnapshotTestCase {
         textView.text = "Example"
         textView.textAlignment = .center
         textView.font = .fairwater(fontSize: 48)
-        FBSnapshotVerifyView(textView)
+        FBSnapshotArchFriendlyVerifyView(textView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Editor/Text/StylableTextViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Editor/Text/StylableTextViewTests.swift
@@ -31,7 +31,7 @@ final class StylableTextViewTests: FBSnapshotTestCase {
         textView.text = "Example"
         textView.textAlignment = .center
         textView.font = .fairwater(fontSize: 48)
-        FBSnapshotVerifyView(textView)
+        FBSnapshotArchFriendlyVerifyView(textView)
     }
     
     func testHitInsideShape() {

--- a/KanvasExample/KanvasExampleTests/Extensions/UIImage+FlipLeftMirroredTests.swift
+++ b/KanvasExample/KanvasExampleTests/Extensions/UIImage+FlipLeftMirroredTests.swift
@@ -28,6 +28,6 @@ final class FlipLeftMirroredTests: FBSnapshotTestCase {
         let view = newView()
         let imageView = UIImageView(image: KanvasImages.imagePreviewOnImage?.flipLeftMirrored())
         imageView.add(into: view)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Extensions/UIImage+PixelBufferTests.swift
+++ b/KanvasExample/KanvasExampleTests/Extensions/UIImage+PixelBufferTests.swift
@@ -38,6 +38,6 @@ final class UIImagePixelBufferTests: FBSnapshotTestCase {
         let newUIImage = UIImage(pixelBuffer: pixelBuffer)
         let imageView = UIImageView(image: newUIImage)
         imageView.add(into: view)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Filters/FilterCollectionInnerCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Filters/FilterCollectionInnerCellTests.swift
@@ -39,6 +39,6 @@ final class FilterCollectionInnerCellTests: FBSnapshotTestCase {
         let cell = newCell()
         let filterItem = FilterItem(type: .lightLeaks)
         cell.bindTo(filterItem)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Filters/FilterCollectionTests.swift
+++ b/KanvasExample/KanvasExampleTests/Filters/FilterCollectionTests.swift
@@ -61,7 +61,7 @@ final class FilterCollectionTests: FBSnapshotTestCase, UICollectionViewDelegate,
         collectionView.delegate = self
         collectionView.dataSource = self
         collectionView.reloadData()
-        FBSnapshotVerifyView(collectionView, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(collectionView, overallTolerance: 0.05)
     }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionCellTests.swift
@@ -35,7 +35,7 @@ final class MediaClipsCollectionCellTests: FBSnapshotTestCase {
         }
 
         cell.bindTo(clip)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/MediaClips/MediaClipsCollectionViewTests.swift
@@ -39,7 +39,7 @@ final class MediaClipsCollectionViewTests: FBSnapshotTestCase, UICollectionViewD
         view.collectionView.delegate = self
         view.collectionView.dataSource = self
         view.collectionView.reloadData()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/KanvasExample/KanvasExampleTests/MediaFormats/GIFDecoderTests.swift
+++ b/KanvasExample/KanvasExampleTests/MediaFormats/GIFDecoderTests.swift
@@ -65,7 +65,7 @@ final class GIFDecoderTests: FBSnapshotTestCase {
                 view.frame = CGRect(x: 0, y: 0, width: frame.image.width, height: frame.image.height)
                 view.image = UIImage(cgImage: frame.image)
                 view.layoutIfNeeded()
-                self.FBSnapshotVerifyView(view, identifier: "\(i)")
+                self.FBSnapshotArchFriendlyVerifyView(view, identifier: "\(i)")
             }
         }
     }

--- a/KanvasExample/KanvasExampleTests/MediaFormats/GIFEncoderTests.swift
+++ b/KanvasExample/KanvasExampleTests/MediaFormats/GIFEncoderTests.swift
@@ -89,7 +89,7 @@ final class GIFEncoderTests: FBSnapshotTestCase {
                 let image = UIImage(cgImage: firstCGImage)
                 view.frame = CGRect(origin: .zero, size: image.size)
                 view.image = image
-                self.FBSnapshotVerifyView(view, identifier: "first")
+                self.FBSnapshotArchFriendlyVerifyView(view, identifier: "first")
 
                 let someLastCGImage = CGImageSourceCreateImageAtIndex(source, actualFrameCount - Int(Double(gifFramesPerSecond) / 2.0), nil)
                 XCTAssertNotNil(someLastCGImage)
@@ -102,7 +102,7 @@ final class GIFEncoderTests: FBSnapshotTestCase {
                 let image1 = UIImage(cgImage: lastCGImage)
                 view1.frame = CGRect(origin: .zero, size: image1.size)
                 view1.image = image1
-                self.FBSnapshotVerifyView(view1, identifier: "last")
+                self.FBSnapshotArchFriendlyVerifyView(view1, identifier: "last")
 
                 expectation.fulfill()
             }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/MediaPickerButtonViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/MediaPickerButtonViewTests.swift
@@ -25,7 +25,7 @@ final class MediaPickerButtonViewTests: FBSnapshotTestCase {
         if let image = Bundle(for: type(of: self)).path(forResource: "sample", ofType: "png").flatMap({ UIImage(contentsOfFile: $0) }) {
             view.setThumbnail(image)
         }
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testButtonDisabled() {
@@ -36,7 +36,7 @@ final class MediaPickerButtonViewTests: FBSnapshotTestCase {
         if let image = Bundle(for: type(of: self)).path(forResource: "sample", ofType: "png").flatMap({ UIImage(contentsOfFile: $0) }) {
             view.setThumbnail(image)
         }
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeButtonViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeButtonViewTests.swift
@@ -29,7 +29,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .photo))
-        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
     
@@ -39,7 +39,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .loop))
-        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
 
@@ -49,7 +49,7 @@ final class ModeButtonViewTests: FBSnapshotTestCase {
         modeButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         modeButton.setTitle(KanvasStrings.name(for: .stopMotion))
-        FBSnapshotVerifyView(modeButton, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(modeButton, overallTolerance: 0.05)
         UIView.setAnimationsEnabled(true)
     }
 }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootControllerTests.swift
@@ -34,13 +34,13 @@ final class ModeSelectorAndShootControllerTests: FBSnapshotTestCase {
     func testShowMode() {
         let viewController = newViewController()
         viewController.showModeButton()
-        FBSnapshotVerifyView(viewController.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(viewController.view, overallTolerance: 0.05)
     }
 
     func testHideMode() {
         let viewController = newViewController()
         viewController.hideModeButton()
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
     }
 
     func testSetMode() {
@@ -48,7 +48,7 @@ final class ModeSelectorAndShootControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.setMode(.stopMotion, from: .loop)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(viewController.view, overallTolerance: 0.05)
     }
 
     func testModeTap() {

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ModeSelectorAndShootViewTests.swift
@@ -27,19 +27,19 @@ final class ModeSelectorAndShootViewTests: FBSnapshotTestCase {
     func testPhotoMode() {
         let view = newView()
         view.setUpMode(.photo)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testGifMode() {
         let view = newView()
         view.setUpMode(.loop)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testStopMotionMode() {
         let view = newView()
         view.setUpMode(.stopMotion)
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
 
     func testShowModeButton() {
@@ -47,7 +47,7 @@ final class ModeSelectorAndShootViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.showModeButton(true)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testHideModeButton() {
@@ -55,7 +55,7 @@ final class ModeSelectorAndShootViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.showModeButton(false)
         UIImageView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/ModeSelector/ShootButtonViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/ModeSelector/ShootButtonViewTests.swift
@@ -29,7 +29,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         shootButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         shootButton.configureFor(trigger: .tap, image: KanvasImages.photoModeImage, timeLimit: KanvasTimes.stopMotionFrameTimeInterval)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
         UIView.setAnimationsEnabled(true)
     }
 
@@ -39,7 +39,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         shootButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         shootButton.configureFor(trigger: .tap, image: KanvasImages.loopModeImage, timeLimit: KanvasTimes.gifTapRecordingTime)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
         UIView.setAnimationsEnabled(true)
     }
 
@@ -49,7 +49,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         shootButton.add(into: uiView)
         UIView.setAnimationsEnabled(false)
         shootButton.configureFor(trigger: .tapOrHold(animateCircle: true), image: KanvasImages.stopMotionModeImage, timeLimit: KanvasTimes.videoRecordingTime)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
         UIView.setAnimationsEnabled(true)
     }
     
@@ -60,7 +60,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         shootButton.openTrash()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
     }
     
     func testShowClosedTrash() {
@@ -70,7 +70,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         shootButton.closeTrash()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
     }
     
     func testOpenAndHideTrash() {
@@ -81,7 +81,7 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         shootButton.openTrash()
         shootButton.hideTrash()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
     }
     
     func testCloseAndHideTrash() {
@@ -92,6 +92,6 @@ final class ShootButtonViewTests: FBSnapshotTestCase {
         shootButton.openTrash()
         shootButton.hideTrash()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(shootButton)
+        FBSnapshotArchFriendlyVerifyView(shootButton)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Options/OptionViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Options/OptionViewTests.swift
@@ -22,7 +22,7 @@ final class OptionViewTests: FBSnapshotTestCase {
         if let image = KanvasImages.flashOffImage {
             let button = OptionView(image: image, backgroundColor: .clear)
             button.frame = CGRect(x: 0, y: 0, width: 100, height: 100)
-            FBSnapshotVerifyView(button)
+            FBSnapshotArchFriendlyVerifyView(button)
         }
         else {
             XCTFail("Bundle image not found")

--- a/KanvasExample/KanvasExampleTests/Options/OptionsControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Options/OptionsControllerTests.swift
@@ -50,7 +50,7 @@ final class OptionsControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.optionWasTapped(section: 0, optionIndex: 0)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         // Test that the option was correctly changed
         XCTAssertEqual(options[0][0].option, "Option 1.2")
         if case let .twoOptionsImages(alternateOption: otherOption, alternateImage: _, alternateBackgroundColor: _) = options[0][0].type {
@@ -67,7 +67,7 @@ final class OptionsControllerTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         viewController.optionWasTapped(section: 0, optionIndex: 1)
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(viewController.view)
+        FBSnapshotArchFriendlyVerifyView(viewController.view)
         // Test that the animation was made
         RunLoop.main.run(until: Date())
         XCTAssert(animationCalled, "Animation not called")

--- a/KanvasExample/KanvasExampleTests/Options/OptionsStackViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Options/OptionsStackViewTests.swift
@@ -35,6 +35,6 @@ final class OptionsStackViewTests: FBSnapshotTestCase {
         let stackView = newStackView()
         let options = self.options()
         stackView.changeOptions(to: options)
-        FBSnapshotVerifyView(stackView)
+        FBSnapshotArchFriendlyVerifyView(stackView)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Rendering/MediaPlayerViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Rendering/MediaPlayerViewTests.swift
@@ -33,7 +33,7 @@ class MediaPlayerViewTests: FBSnapshotTestCase {
         player.playerView = view
         player.play(media: [.image(image, nil)])
         RunLoop.main.run(until: Date.init(timeIntervalSinceNow: 2))
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Rendering/OpenGL/GLPixelBufferViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Rendering/OpenGL/GLPixelBufferViewTests.swift
@@ -33,7 +33,7 @@ class GLPixelBufferViewTests: FBSnapshotTestCase {
             }
             _ = view
             RunLoop.current.run(until: Date(timeIntervalSinceNow: 2.0))
-            FBSnapshotVerifyView(view)
+            FBSnapshotArchFriendlyVerifyView(view)
         }
         else {
             XCTAssert(false, "Failed to load sample.png")

--- a/KanvasExample/KanvasExampleTests/TestHelpers/FBSnapshotTest+M1Compatability.swift
+++ b/KanvasExample/KanvasExampleTests/TestHelpers/FBSnapshotTest+M1Compatability.swift
@@ -1,0 +1,38 @@
+//
+//  FBSnapshotTest+M1Compatability.swift
+//  KanvasExampleTests
+//
+//  Created by Declan McKenna on 22/04/2022.
+//  Copyright © 2022 Tumblr. All rights reserved.
+//
+
+import Foundation
+import FBSnapshotTestCase
+import UIKit
+
+/// Set between 0 and 1
+fileprivate let defaultArm64CompatiblePerPixelTolerance: CGFloat = 0.02
+/// Set between 0 and 1
+fileprivate let defaultArm64CompatibleOverallTolerance: CGFloat = 0.002
+
+extension FBSnapshotTestCase {
+    func FBSnapshotArchFriendlyVerifyViewController(_ viewController: UIViewController,
+                                                    identifier: String? = nil,
+                                                    perPixelTolerance: CGFloat = defaultArm64CompatiblePerPixelTolerance,
+                                                    overallTolerance:CGFloat = defaultArm64CompatibleOverallTolerance) {
+        FBSnapshotVerifyViewController(viewController,
+                                       identifier: identifier,
+                                       perPixelTolerance: perPixelTolerance,
+                                       overallTolerance: overallTolerance)
+    }
+    
+    func FBSnapshotArchFriendlyVerifyView(_ view: UIView,
+                                          identifier: String? = nil,
+                                          perPixelTolerance: CGFloat = defaultArm64CompatiblePerPixelTolerance,
+                                          overallTolerance:CGFloat = defaultArm64CompatibleOverallTolerance) {
+        FBSnapshotVerifyView(view,
+                             identifier: identifier,
+                             perPixelTolerance: perPixelTolerance,
+                             overallTolerance: overallTolerance)
+    }
+}

--- a/KanvasExample/KanvasExampleTests/Utility/ConicalGradientLayerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/ConicalGradientLayerTests.swift
@@ -31,6 +31,6 @@ final class ConicalGradientLayerTests: FBSnapshotTestCase {
                            .tumblrBrightPurple,
                            .tumblrBrightRed]
         view.layer.addSublayer(gradient)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Utility/LoadingIndicatorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/LoadingIndicatorViewTests.swift
@@ -27,7 +27,7 @@ final class LoadingIndicatorViewTests: FBSnapshotTestCase {
 
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testStartLoading() {
@@ -35,7 +35,7 @@ final class LoadingIndicatorViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         view.startLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testStopLoading() {
@@ -44,7 +44,7 @@ final class LoadingIndicatorViewTests: FBSnapshotTestCase {
         view.startLoading()
         view.stopLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
     func testStartAfterStopLoading() {
@@ -54,7 +54,7 @@ final class LoadingIndicatorViewTests: FBSnapshotTestCase {
         view.stopLoading()
         view.startLoading()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(view)
+        FBSnapshotArchFriendlyVerifyView(view)
     }
 
 }

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorCellTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorCellTests.swift
@@ -27,13 +27,13 @@ final class OptionSelectorCellTests: FBSnapshotTestCase {
     func testCell() {
         let cell = newCell()
         cell.bindTo(PlaybackOption.loop)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
     
     func testSelectedCell() {
         let cell = newCell()
         cell.bindTo(PlaybackOption.loop)
         cell.setSelected(true, animated: false)
-        FBSnapshotVerifyView(cell, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(cell, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorControllerTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorControllerTests.swift
@@ -29,6 +29,6 @@ final class OptionSelectorControllerTests: FBSnapshotTestCase {
     
     func testControllerView() {
         let controller = newViewController()
-        FBSnapshotVerifyView(controller.view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(controller.view, overallTolerance: 0.05)
     }
 }

--- a/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/OptionSelector/OptionSelectorViewTests.swift
@@ -35,7 +35,7 @@ final class OptionSelectorViewTests: FBSnapshotTestCase, UICollectionViewDataSou
     
     func testViewSetup() {
         let view = newView()
-        FBSnapshotVerifyView(view, overallTolerance: 0.05)
+        FBSnapshotArchFriendlyVerifyView(view, overallTolerance: 0.05)
     }
     
     // MARK: - UICollectionViewDataSource

--- a/KanvasExample/KanvasExampleTests/Utility/TrashViewTests.swift
+++ b/KanvasExample/KanvasExampleTests/Utility/TrashViewTests.swift
@@ -29,7 +29,7 @@ final class TrashViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         trashView.open()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(trashView)
+        FBSnapshotArchFriendlyVerifyView(trashView)
     }
     
     func testShowClosedTrash() {
@@ -37,7 +37,7 @@ final class TrashViewTests: FBSnapshotTestCase {
         UIView.setAnimationsEnabled(false)
         trashView.close()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(trashView)
+        FBSnapshotArchFriendlyVerifyView(trashView)
     }
     
     func testOpenAndHideTrash() {
@@ -46,7 +46,7 @@ final class TrashViewTests: FBSnapshotTestCase {
         trashView.open()
         trashView.hide()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(trashView)
+        FBSnapshotArchFriendlyVerifyView(trashView)
     }
     
     func testCloseAndHideTrash() {
@@ -55,7 +55,7 @@ final class TrashViewTests: FBSnapshotTestCase {
         trashView.close()
         trashView.hide()
         UIView.setAnimationsEnabled(true)
-        FBSnapshotVerifyView(trashView)
+        FBSnapshotArchFriendlyVerifyView(trashView)
     }
 
 }


### PR DESCRIPTION
Utilizes FBSnapshot's perPixel Tolerance to enable accurate snapshot testing that will pass on M1 and intel devices regardless of where the snapshot was taken.

(2nd commit is literally a huge find and replace)