### PR TITLE
Removes “Tumblr” from a string and rename it

### DIFF
--- a/Classes/Constants/KanvasStrings.swift
+++ b/Classes/Constants/KanvasStrings.swift
@@ -50,7 +50,7 @@ public struct KanvasStrings {
                                              cameraPermissionsDescriptionLabel: cameraPermissionDescriptionString)
     
     private static let cameraPermissionTitleString = {
-        NSLocalizedString("Please allow Tumblr access to your Camera and Microphone",
+        NSLocalizedString("CameraAccessNoAccessTitle",
                           comment: "Title text for scenerio when access to Photos has been disallowed")
     }()
     

--- a/KanvasExample/KanvasExample/en.lproj/Localizable.strings
+++ b/KanvasExample/KanvasExample/en.lproj/Localizable.strings
@@ -44,7 +44,7 @@
 "Post" = "Post";
 
 /* Title text for scenerio when access to Photos has been disallowed */
-"Please allow Tumblr access to your Camera and Microphone" = "Please allow Tumblr access to your Camera and Microphone";
+"CameraAccessNoAccessTitle" = "Please allow access to your camera and Microphone";
 
 /* Description text for scenerio when access to Photos has been disallowed */
 "CameraAccessNoAccessDesc" = "You might want to save your post as a draft first so you don’t lose any unsaved progress.";


### PR DESCRIPTION
- Remove the "Tumblr" word from one of the strings
- Move the string to use the original key (It was mistakenly changed)