### PR TITLE
Reduce renderer memory consumption when exporting

### DIFF
--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -387,12 +387,14 @@ extension MultiEditorViewController: EditorControllerDelegate {
                 editor.export { [weak self, editor] result in
                     let _ = editor // strong reference until the export completes
                     self?.exportHandler.handleExport(result, for: idx)
-                    if let selected = self?.selected {
-                        self?.loadEditor(for: selected, current: false)
-                    }
                 }
             }
         })
+
+        if let selected = self.selected {
+            loadEditor(for: selected, current: true)
+        }
+
         return false
     }
 

--- a/Classes/Rendering/Renderer.swift
+++ b/Classes/Rendering/Renderer.swift
@@ -163,6 +163,8 @@ final class Renderer: Rendering {
     /// For this to work, all access to filteredPixelBuffer should be locked, so this method should be called in
     /// a synchronized(self) block.
     private func output(filteredPixelBuffer: CVPixelBuffer) {
+        guard let delegate = self.delegate else { return }
+
         self.filteredPixelBuffer = filteredPixelBuffer
         callbackQueue.async {
             let pixelBuffer: CVPixelBuffer? = synchronized(self) {
@@ -173,7 +175,7 @@ final class Renderer: Rendering {
                 return pixelBuffer
             }
             if let filteredPixelBuffer = pixelBuffer {
-                self.delegate?.rendererReadyForDisplay(pixelBuffer: filteredPixelBuffer)
+                delegate.rendererReadyForDisplay(pixelBuffer: filteredPixelBuffer)
             }
         }
     }

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.4.2'
+  spec.version      = '1.4.3'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
## Description

Memory consumption grows constantly when exporting multiple images due to calls to [`output`](https://github.com/tumblr/kanvas-ios/blob/4d715e09cae64acf149befcdff68e55e85af52b1/Classes/Rendering/Renderer.swift#L165) in the renderer. In instances where there's no delegate to process the renderer's pixel buffer, we can avoid running the function altogether.

This will help alleviate WPiOS out-of-memory crashes:
- [Related WPiOS issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/18550)
