### PR TITLE
temporalImageView is not supposed to be visible

### DIFF
--- a/Classes/Editor/Drawing/DrawingView.swift
+++ b/Classes/Editor/Drawing/DrawingView.swift
@@ -639,7 +639,6 @@ final class DrawingView: IgnoreTouchesView, DrawingCanvasDelegate {
     func showCanvas(_ show: Bool) {
         UIView.animate(withDuration: Constants.animationDuration) {
             self.drawingCanvas.alpha = show ? 1 : 0
-            self.temporalImageView.alpha = show ? 1 : 0
         }
     }
     


### PR DESCRIPTION
### Issue
When the color picker tool is used, [`DrawingController::showCanvas` gets called](https://github.com/tumblr/kanvas-ios/blob/main/Classes/Editor/EditorViewController.swift#L1196), which sets `DrawingView::temporalImageView`'s alpha to be 1. But as far as I can see, `temporalImageView` is not supposed to be visible as it works as just a buffer to hold a drawing stroke. 

### How to test
1. Run KanvasExample
2. Start
3. Select a picture to go to the editor screen
4. Select the drawing tool 
5. Select the color picker and pick color from the picture
6. Try to draw a line

Make sure the line drawn in the step 6 is not duplicated. 