### PR TITLE
Remove xcode 14 deprecations

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -85,7 +85,7 @@ enum CameraControllerError: Swift.Error {
 
 // Protocol for dismissing CameraController
 // or exporting its created media.
-public protocol CameraControllerDelegate: class {
+public protocol CameraControllerDelegate: AnyObject {
 
     /**
      A function that is called when an image is exported. Can be nil if the export fails

--- a/Classes/Camera/CameraInputControllerDelegate.swift
+++ b/Classes/Camera/CameraInputControllerDelegate.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Delegate for handling camera input actions
-protocol CameraInputControllerDelegate: class {
+protocol CameraInputControllerDelegate: AnyObject {
     /// Delegate to reset the current device zoom
     func cameraInputControllerShouldResetZoom()
     

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -240,6 +240,8 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
             }
         case .restricted, .denied, .authorized:
             return
+        @unknown default:
+            return
         }
     }
 
@@ -252,6 +254,8 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
                 }
             }
         case .restricted, .denied, .authorized:
+            return
+        @unknown default:
             return
         }
     }

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 import AVFoundation
 
-protocol CaptureDeviceAuthorizing: class {
+protocol CaptureDeviceAuthorizing: AnyObject {
 
     func requestAccess(for mediaType: AVMediaType, completionHandler: @escaping (Bool) -> ())
 
@@ -16,7 +16,7 @@ protocol CaptureDeviceAuthorizing: class {
 
 }
 
-protocol CameraPermissionsViewDelegate: class {
+protocol CameraPermissionsViewDelegate: AnyObject {
 
     func requestCameraAccess()
     
@@ -25,7 +25,7 @@ protocol CameraPermissionsViewDelegate: class {
     func openAppSettings()
 }
 
-protocol CameraPermissionsViewControllerDelegate: class {
+protocol CameraPermissionsViewControllerDelegate: AnyObject {
 
     func cameraPermissionsChanged(hasFullAccess: Bool)
 

--- a/Classes/Camera/CameraView.swift
+++ b/Classes/Camera/CameraView.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Protocol for handling CameraView's interaction.
-protocol CameraViewDelegate: class {
+protocol CameraViewDelegate: AnyObject {
     /// A function that is called when the close button is pressed
     func closeButtonPressed()
 }

--- a/Classes/Camera/CameraZoomHandler.swift
+++ b/Classes/Camera/CameraZoomHandler.swift
@@ -14,7 +14,7 @@ private struct CameraZoomConstants {
 }
 
 /// protocol for handling the current zoom on a device
-protocol CameraZoomHandlerDelegate: class {
+protocol CameraZoomHandlerDelegate: AnyObject {
     /// Gets the current device for zooming
     var currentDeviceForZooming: AVCaptureDevice? { get }
 }

--- a/Classes/Camera/FilteredInputViewController.swift
+++ b/Classes/Camera/FilteredInputViewController.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Callback protocol for the filters
-protocol FilteredInputViewControllerDelegate: class {
+protocol FilteredInputViewControllerDelegate: AnyObject {
     /// Method to return a filtered pixel buffer
     ///
     /// - Parameter pixelBuffer: the final pixel buffer

--- a/Classes/Camera/Filters/CameraFilterCollectionController.swift
+++ b/Classes/Camera/Filters/CameraFilterCollectionController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol CameraFilterCollectionControllerDelegate: class {
+protocol CameraFilterCollectionControllerDelegate: AnyObject {
     /// Callback for when a filter item is selected
     ///
     /// - Parameter filterItem: the selected filter

--- a/Classes/Camera/Filters/FilterSettingsController.swift
+++ b/Classes/Camera/Filters/FilterSettingsController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol FilterSettingsControllerDelegate: class {
+protocol FilterSettingsControllerDelegate: AnyObject {
     /// Callback for when a filter item is selected
     ///
     /// - Parameter filterItem: the selected filter

--- a/Classes/Camera/Filters/FilterSettingsView.swift
+++ b/Classes/Camera/Filters/FilterSettingsView.swift
@@ -15,7 +15,7 @@ private struct FilterSettingsViewConstants {
     static let height: CGFloat = collectionViewHeight + padding + iconSize
 }
 
-protocol FilterSettingsViewDelegate: class {
+protocol FilterSettingsViewDelegate: AnyObject {
     /// Callback for when the button that shows/hides the filter selector is tapped
     func didTapVisibilityButton()
 }

--- a/Classes/Editor/Drawing/DrawingCanvas.swift
+++ b/Classes/Editor/Drawing/DrawingCanvas.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol DrawingCanvasDelegate: class {
+protocol DrawingCanvasDelegate: AnyObject {
     func didBeginTouches()
     func didEndTouches()
 }

--- a/Classes/Editor/Drawing/DrawingController.swift
+++ b/Classes/Editor/Drawing/DrawingController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol DrawingControllerDelegate: class {
+protocol DrawingControllerDelegate: AnyObject {
     /// Called to ask if color selector tooltip should be shown
     ///
     /// - Returns: Bool for tooltip

--- a/Classes/Editor/Drawing/DrawingView.swift
+++ b/Classes/Editor/Drawing/DrawingView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol DrawingViewDelegate: class {
+protocol DrawingViewDelegate: AnyObject {
     
     /// Called when the confirm button is selected
     func didTapConfirmButton()

--- a/Classes/Editor/Drawing/StrokeSelector/StrokeSelectorController.swift
+++ b/Classes/Editor/Drawing/StrokeSelector/StrokeSelectorController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol StrokeSelectorControllerDelegate: class {
+protocol StrokeSelectorControllerDelegate: AnyObject {
     /// Called before the animation for onboarding begins
     func didAnimationStart()
     

--- a/Classes/Editor/Drawing/StrokeSelector/StrokeSelectorView.swift
+++ b/Classes/Editor/Drawing/StrokeSelector/StrokeSelectorView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol StrokeSelectorViewDelegate: class {
+protocol StrokeSelectorViewDelegate: AnyObject {
     /// Called when the main button is held
     ///
     /// - Parameter recognizer: the long press gesture recognizer

--- a/Classes/Editor/Drawing/TextureSelector/TextureSelectorController.swift
+++ b/Classes/Editor/Drawing/TextureSelector/TextureSelectorController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol TextureSelectorControllerDelegate: class {
+protocol TextureSelectorControllerDelegate: AnyObject {
     func didSelectTexture(textureType: KanvasBrushType)
 }
 

--- a/Classes/Editor/Drawing/TextureSelector/TextureSelectorView.swift
+++ b/Classes/Editor/Drawing/TextureSelector/TextureSelectorView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol TextureSelectorViewDelegate: class {
+protocol TextureSelectorViewDelegate: AnyObject {
     /// Called when the main button is selected
     func didTapTextureButton()
     

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -34,7 +34,7 @@ struct FullViewConstraints {
 }
 
 /// protocol for closing the preview or confirming
-protocol EditorViewDelegate: class {
+protocol EditorViewDelegate: AnyObject {
     /// Called when the confirm button is pressed
     func didTapConfirmButton()
     /// Called when the close button is pressed

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Protocol for camera editor controller methods
 
-public protocol EditorControllerDelegate: class {
+public protocol EditorControllerDelegate: AnyObject {
     /// callback when finished exporting video clips.
     func didFinishExportingVideo(url: URL?, info: MediaInfo?, archive: Data?, action: KanvasExportAction, mediaChanged: Bool)
 

--- a/Classes/Editor/Filters/EditorFilterCollectionController.swift
+++ b/Classes/Editor/Filters/EditorFilterCollectionController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol EditorFilterCollectionControllerDelegate: class {
+protocol EditorFilterCollectionControllerDelegate: AnyObject {
     /// Callback for when a filter item is selected
     ///
     /// - Parameter filterItem: the selected filter

--- a/Classes/Editor/Filters/EditorFilterController.swift
+++ b/Classes/Editor/Filters/EditorFilterController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Protocol for confirming and selecting filters
 
-protocol EditorFilterControllerDelegate: class {
+protocol EditorFilterControllerDelegate: AnyObject {
     /// Callback for when the user taps the background to confirm
     func didConfirmFilters()
     

--- a/Classes/Editor/Filters/EditorFilterView.swift
+++ b/Classes/Editor/Filters/EditorFilterView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Protocol for closing the filters
-protocol EditorFilterViewDelegate: class {
+protocol EditorFilterViewDelegate: AnyObject {
     
     /// Called when the user taps the background to confirm
     func didTapBackground()

--- a/Classes/Editor/GIFMaker/GifMakerController.swift
+++ b/Classes/Editor/GIFMaker/GifMakerController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for editing GIFs
-protocol GifMakerControllerDelegate: class {
+protocol GifMakerControllerDelegate: AnyObject {
     
     /// Called after the confirm button is tapped
     func didConfirmGif()

--- a/Classes/Editor/GIFMaker/GifMakerHandler.swift
+++ b/Classes/Editor/GIFMaker/GifMakerHandler.swift
@@ -47,7 +47,7 @@ func MediaFrameGetEndTimestamp(_ frames: [MediaFrame], at index: Int) -> TimeInt
     }
 }
 
-protocol GifMakerHandlerDelegate: class {
+protocol GifMakerHandlerDelegate: AnyObject {
     func didConfirmGif()
 
     func didRevertGif()

--- a/Classes/Editor/GIFMaker/GifMakerView.swift
+++ b/Classes/Editor/GIFMaker/GifMakerView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for closing the GIF maker
-protocol GifMakerViewDelegate: class {
+protocol GifMakerViewDelegate: AnyObject {
     
     /// Called when the confirm button is selected
     func didTapConfirmButton()

--- a/Classes/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSlider.swift
+++ b/Classes/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSlider.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting items.
-protocol DiscreteSliderDelegate: class {
+protocol DiscreteSliderDelegate: AnyObject {
     /// Called when a new value is selected.
     ///
     /// - Parameter item: the selected item.

--- a/Classes/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderView.swift
+++ b/Classes/Editor/GIFMaker/Speed/DiscreteSlider/DiscreteSliderView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting cells.
-protocol DiscreteSliderViewDelegate: class {
+protocol DiscreteSliderViewDelegate: AnyObject {
     
     /// Called when a cell is selected.
     ///

--- a/Classes/Editor/GIFMaker/Speed/SpeedController.swift
+++ b/Classes/Editor/GIFMaker/Speed/SpeedController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for the speed controller
-protocol SpeedControllerDelegate: class {
+protocol SpeedControllerDelegate: AnyObject {
     
     /// Called when a new speed is selected.
     ///

--- a/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionCell.swift
+++ b/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for obtaining images.
-protocol ThumbnailCollectionCellDelegate: class {
+protocol ThumbnailCollectionCellDelegate: AnyObject {
     
     /// Obtains a thumbnail for the background of the trimming tool
     ///

--- a/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionController.swift
+++ b/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for obtaining images.
-protocol ThumbnailCollectionControllerDelegate: class {
+protocol ThumbnailCollectionControllerDelegate: AnyObject {
     
     /// Obtains the full media duration
     func getMediaDuration() -> TimeInterval?

--- a/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionViewLayout.swift
+++ b/Classes/Editor/GIFMaker/Trim/ThumbnailCollection/ThumbnailCollectionViewLayout.swift
@@ -4,7 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 
-protocol ThumbnailCollectionViewLayoutDelegate: class {
+protocol ThumbnailCollectionViewLayoutDelegate: AnyObject {
     func collectionView(_ collectionView: UICollectionView, widthForCellAt indexPath: IndexPath) -> CGFloat
 }
 

--- a/Classes/Editor/GIFMaker/Trim/TrimArea.swift
+++ b/Classes/Editor/GIFMaker/Trim/TrimArea.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for changes in the trimming range
-protocol TrimAreaDelegate: class {
+protocol TrimAreaDelegate: AnyObject {
     func didMoveLeftSide(recognizer: UIGestureRecognizer)
     func didMoveRightSide(recognizer: UIGestureRecognizer)
 }

--- a/Classes/Editor/GIFMaker/Trim/TrimController.swift
+++ b/Classes/Editor/GIFMaker/Trim/TrimController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for the trim controller
-protocol TrimControllerDelegate: class {
+protocol TrimControllerDelegate: AnyObject {
     /// Called after a trimming movement starts
     func didStartTrimming()
 

--- a/Classes/Editor/GIFMaker/Trim/TrimView.swift
+++ b/Classes/Editor/GIFMaker/Trim/TrimView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for trimming
-protocol TrimViewDelegate: class {
+protocol TrimViewDelegate: AnyObject {
     /// Called after a trimming movement starts
     func didStartMovingTrimArea()
     

--- a/Classes/Editor/Media/MediaDrawerController.swift
+++ b/Classes/Editor/Media/MediaDrawerController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting a sticker and dimissing the media drawer
-protocol MediaDrawerControllerDelegate: class {
+protocol MediaDrawerControllerDelegate: AnyObject {
     /// Callback for when a sticker is selected
     ///
     /// - Parameters

--- a/Classes/Editor/Media/MediaDrawerView.swift
+++ b/Classes/Editor/Media/MediaDrawerView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol MediaDrawerViewDelegate: class {
+protocol MediaDrawerViewDelegate: AnyObject {
     /// Called when the close button is tapped
     func didTapCloseButton()
 }

--- a/Classes/Editor/Media/Stickers/StickerCollection/StickerCollectionCell.swift
+++ b/Classes/Editor/Media/Stickers/StickerCollection/StickerCollectionCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol StickerCollectionCellDelegate: class {
+protocol StickerCollectionCellDelegate: AnyObject {
     /// Callback method for when tapping a cell
     ///
     /// - Parameters:

--- a/Classes/Editor/Media/Stickers/StickerCollection/StickerCollectionController.swift
+++ b/Classes/Editor/Media/Stickers/StickerCollection/StickerCollectionController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting a sticker
-protocol StickerCollectionControllerDelegate: class {
+protocol StickerCollectionControllerDelegate: AnyObject {
     /// Callback for when a sticker is selected
     /// 
     /// - Parameters

--- a/Classes/Editor/Media/Stickers/StickerMenuController.swift
+++ b/Classes/Editor/Media/Stickers/StickerMenuController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for confirming a sticker
-protocol StickerMenuControllerDelegate: class {
+protocol StickerMenuControllerDelegate: AnyObject {
     /// Callback for when a sticker is selected
     ///
     /// - Parameters

--- a/Classes/Editor/Media/Stickers/StickerProvider/StickerProvider.swift
+++ b/Classes/Editor/Media/Stickers/StickerProvider/StickerProvider.swift
@@ -4,7 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
 
-public protocol StickerProviderDelegate: class {
+public protocol StickerProviderDelegate: AnyObject {
     /// Callback for when the sticker request has finished loading
     ///
     /// - Parameter stickerTypes: the collection of sticker types from the API

--- a/Classes/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionCell.swift
+++ b/Classes/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol StickerTypeCollectionCellDelegate: class {
+protocol StickerTypeCollectionCellDelegate: AnyObject {
     /// Callback method when selecting a cell
     ///
     /// - Parameters:

--- a/Classes/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionController.swift
+++ b/Classes/Editor/Media/Stickers/StickerTypeCollection/StickerTypeCollectionController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting a sticker type
-protocol StickerTypeCollectionControllerDelegate: class {
+protocol StickerTypeCollectionControllerDelegate: AnyObject {
     /// Callback for when a sticker type is selected
     ///
     /// - Parameter sticker: the selected sticker type

--- a/Classes/Editor/Media/TabBar/DrawerTabBarCell.swift
+++ b/Classes/Editor/Media/TabBar/DrawerTabBarCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol DrawerTabBarCellDelegate: class {
+protocol DrawerTabBarCellDelegate: AnyObject {
     /// Callback method when tapping a cell
     ///
     /// - Parameters:

--- a/Classes/Editor/Media/TabBar/DrawerTabBarController.swift
+++ b/Classes/Editor/Media/TabBar/DrawerTabBarController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Constants for selecting a tab
-protocol DrawerTabBarControllerDelegate: class {
+protocol DrawerTabBarControllerDelegate: AnyObject {
     func didSelectOption(_ option: DrawerTabBarOption)
 }
 

--- a/Classes/Editor/Menu/EditionMenu/EditionMenuCollectionCell.swift
+++ b/Classes/Editor/Menu/EditionMenu/EditionMenuCollectionCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol EditionMenuCollectionCellDelegate: class {
+protocol EditionMenuCollectionCellDelegate: AnyObject {
     /// Callback method when tapping a cell
     ///
     /// - Parameters:

--- a/Classes/Editor/Menu/Shared/KanvasEditorMenuController.swift
+++ b/Classes/Editor/Menu/Shared/KanvasEditorMenuController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for tap events on the editor menu.
-protocol KanvasEditorMenuControllerDelegate: class {
+protocol KanvasEditorMenuControllerDelegate: AnyObject {
     
     /// Callback for the selection of an option.
     ///

--- a/Classes/Editor/Menu/StyleMenu/StyleMenuCell.swift
+++ b/Classes/Editor/Menu/StyleMenu/StyleMenuCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell.
-protocol StyleMenuCellDelegate: class {
+protocol StyleMenuCellDelegate: AnyObject {
     
     /// Callback method when tapping a cell.
     ///

--- a/Classes/Editor/Menu/StyleMenu/StyleMenuExpandCell.swift
+++ b/Classes/Editor/Menu/StyleMenu/StyleMenuExpandCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell.
-protocol StyleMenuExpandCellDelegate: class {
+protocol StyleMenuExpandCellDelegate: AnyObject {
     
     /// Callback method when tapping a cell.
     ///

--- a/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
+++ b/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
@@ -415,7 +415,7 @@ final class StyleMenuView: IgnoreTouchesView, StyleMenuCellDelegate, StyleMenuEx
     ///
     /// - Parameter cell: the cell.
     func getIndex(for cell: StyleMenuCell) -> Int? {
-        return cells.index(of: cell)
+        return cells.firstIndex(of: cell)
     }
     
     /// Reloads a specific cell.

--- a/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
+++ b/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for cell binding and touch events.
-protocol StyleMenuViewDelegate: class {
+protocol StyleMenuViewDelegate: AnyObject {
     
     /// Called to obtain the size of the collection.
     func numberOfItems() -> Int
@@ -482,7 +482,7 @@ final class StyleMenuView: IgnoreTouchesView, StyleMenuCellDelegate, StyleMenuEx
 }
 
 /// Protocol for touch events.
-private protocol StyleMenuScrollViewDelegate: class {
+private protocol StyleMenuScrollViewDelegate: AnyObject {
     
     /// Called when the scroll view is touched outside its content.
     func didTouchEmptySpace()

--- a/Classes/Editor/MovableViews/MovableView.swift
+++ b/Classes/Editor/MovableViews/MovableView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for tapping a movable view
-protocol MovableViewDelegate: class {
+protocol MovableViewDelegate: AnyObject {
     /// Callback for when a movable view with text is tapped
     ///
     /// - Parameters

--- a/Classes/Editor/MovableViews/MovableViewCanvas.swift
+++ b/Classes/Editor/MovableViews/MovableViewCanvas.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for movable view canvas methods
-protocol MovableViewCanvasDelegate: class {
+protocol MovableViewCanvasDelegate: AnyObject {
     /// Called when a movable view is tapped
     ///
     /// - Parameter option: text style options

--- a/Classes/Editor/Shared/ColorCollection/ColorCollectionCell.swift
+++ b/Classes/Editor/Shared/ColorCollection/ColorCollectionCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol ColorCollectionCellDelegate: class {
+protocol ColorCollectionCellDelegate: AnyObject {
     /// Callback method when selecting a cell
     ///
     /// - Parameters:

--- a/Classes/Editor/Shared/ColorCollection/ColorCollectionController.swift
+++ b/Classes/Editor/Shared/ColorCollection/ColorCollectionController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol ColorCollectionControllerDelegate: class {
+protocol ColorCollectionControllerDelegate: AnyObject {
     /// Callback for the selection of an color
     ///
     /// - Parameter color: the selected color

--- a/Classes/Editor/Shared/ColorPicker/ColorPickerController.swift
+++ b/Classes/Editor/Shared/ColorPicker/ColorPickerController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol ColorPickerControllerDelegate: class {
+protocol ColorPickerControllerDelegate: AnyObject {
     /// Called when a color is selected
     ///
     /// - Parameter color: the color just selected

--- a/Classes/Editor/Shared/ColorPicker/ColorPickerView.swift
+++ b/Classes/Editor/Shared/ColorPicker/ColorPickerView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol ColorPickerViewDelegate: class {
+protocol ColorPickerViewDelegate: AnyObject {
     /// Called when the selector is tapped
     ///
     /// - Parameter recognizer: the tap gesture recognizer

--- a/Classes/Editor/Shared/ColorSelector/ColorSelectorController.swift
+++ b/Classes/Editor/Shared/ColorSelector/ColorSelectorController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol ColorSelectorControllerDelegate: class {
+protocol ColorSelectorControllerDelegate: AnyObject {
     
     /// Called to ask if tooltip should be shown
     ///

--- a/Classes/Editor/Shared/ColorSelector/ColorSelectorView.swift
+++ b/Classes/Editor/Shared/ColorSelector/ColorSelectorView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for the color selector view
-protocol ColorSelectorViewDelegate: class {
+protocol ColorSelectorViewDelegate: AnyObject {
     
     /// Called when the selection circle is panned
     ///

--- a/Classes/Editor/Text/EditorTextController.swift
+++ b/Classes/Editor/Text/EditorTextController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for confirming the text tools
-protocol EditorTextControllerDelegate: class {
+protocol EditorTextControllerDelegate: AnyObject {
     
     /// Called after the confirm button is tapped
     ///

--- a/Classes/Editor/Text/EditorTextView.swift
+++ b/Classes/Editor/Text/EditorTextView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Protocol for the text tools editor
-protocol EditorTextViewDelegate: class {
+protocol EditorTextViewDelegate: AnyObject {
     
     /// Called when the confirm button is selected
     func didTapConfirmButton()

--- a/Classes/Editor/Text/MainTextView.swift
+++ b/Classes/Editor/Text/MainTextView.swift
@@ -13,7 +13,7 @@ private struct Constants {
 }
 
 /// Protocol for the text view inside text tools
-protocol MainTextViewDelegate: class {
+protocol MainTextViewDelegate: AnyObject {
     
     /// Called when the background was touched
     func didTapBackground()

--- a/Classes/Filters/FilterCollectionCell.swift
+++ b/Classes/Filters/FilterCollectionCell.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Delegate for touch events on this cell
-protocol FilterCollectionCellDelegate: class {
+protocol FilterCollectionCellDelegate: AnyObject {
     /// Callback method when tapping a cell
     ///
     /// - Parameters:

--- a/Classes/Filters/FilterCollectionInnerCell.swift
+++ b/Classes/Filters/FilterCollectionInnerCell.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Delegate for touch events on this cell
-protocol FilterCollectionInnerCellDelegate: class {
+protocol FilterCollectionInnerCellDelegate: AnyObject {
     /// Callback method when tapping a cell
     ///
     /// - Parameters:

--- a/Classes/Filters/ScrollHandler.swift
+++ b/Classes/Filters/ScrollHandler.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol ScrollHandlerDelegate: class {
+protocol ScrollHandlerDelegate: AnyObject {
     func indexPathAtSelectionCircle() -> IndexPath?
     func calculateDistanceFromSelectionCircle(cell: FilterCollectionCell) -> CGFloat
     func selectFilter(index: Int, animated: Bool)

--- a/Classes/MediaClips/MediaClipsCollectionController.swift
+++ b/Classes/MediaClips/MediaClipsCollectionController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol MediaClipsCollectionControllerDelegate: class {
+protocol MediaClipsCollectionControllerDelegate: AnyObject {
     
     /// Callback for when a clip is moved inside the collection
     func mediaClipWasMoved(from originIndex: Int, to destinationIndex: Int)

--- a/Classes/MediaClips/MediaClipsEditorView.swift
+++ b/Classes/MediaClips/MediaClipsEditorView.swift
@@ -21,7 +21,7 @@ private struct Constants {
     static let nextButtonCenterYOffset: CGFloat = KanvasDesign.shared.mediaClipsEditorViewNextButtonCenterYOffset
 }
 
-protocol MediaClipsEditorViewDelegate: class {
+protocol MediaClipsEditorViewDelegate: AnyObject {
     /// Callback for when next button is selected
     func nextButtonWasPressed()
     func addButtonWasPressed()

--- a/Classes/MediaClips/MediaClipsEditorViewController.swift
+++ b/Classes/MediaClips/MediaClipsEditorViewController.swift
@@ -7,7 +7,7 @@
 import Foundation
 import UIKit
 
-protocol MediaClipsEditorDelegate: class {
+protocol MediaClipsEditorDelegate: AnyObject {
     /// Callback for when a clip is deleted
     ///
     /// - Parameter index: the index of the deleted clip

--- a/Classes/MediaPicker/MediaPickerThumbnailFetcher.swift
+++ b/Classes/MediaPicker/MediaPickerThumbnailFetcher.swift
@@ -8,7 +8,7 @@ import Foundation
 
 import Photos
 
-protocol MediaPickerThumbnailFetcherDelegate: class {
+protocol MediaPickerThumbnailFetcherDelegate: AnyObject {
     func didUpdateThumbnail(image: UIImage)
 }
 

--- a/Classes/MediaPicker/MediaPickerViewController.swift
+++ b/Classes/MediaPicker/MediaPickerViewController.swift
@@ -16,7 +16,7 @@ public enum PickedMedia {
     case livePhoto(UIImage, URL)
 }
 
-public protocol KanvasMediaPickerViewControllerDelegate: class {
+public protocol KanvasMediaPickerViewControllerDelegate: AnyObject {
     func didPick(media: [PickedMedia])
     func didCancel()
     func pickingMediaNotAllowed(reason: String)

--- a/Classes/ModeSelector/MediaPickerButtonView.swift
+++ b/Classes/ModeSelector/MediaPickerButtonView.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Media Picker Button Delegate
-protocol MediaPickerButtonViewDelegate: class {
+protocol MediaPickerButtonViewDelegate: AnyObject {
 
     /// Called when the media picker button is pressed
     func mediaPickerButtonDidPress()

--- a/Classes/ModeSelector/ModeButtonView.swift
+++ b/Classes/ModeSelector/ModeButtonView.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Protocol to handle mode button user actions
-protocol ModeButtonViewDelegate: class {
+protocol ModeButtonViewDelegate: AnyObject {
 
     /// Function called when mode button was tapped
     func modeButtonViewDidTap()

--- a/Classes/ModeSelector/ModeSelectorAndShootController.swift
+++ b/Classes/ModeSelector/ModeSelectorAndShootController.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 /// Protocol for handling mode selector and capture button events
-protocol ModeSelectorAndShootControllerDelegate: class {
+protocol ModeSelectorAndShootControllerDelegate: AnyObject {
     /// Function called when a mode was selected
     ///
     /// - Parameter mode: selected mode

--- a/Classes/ModeSelector/ShootButtonView.swift
+++ b/Classes/ModeSelector/ShootButtonView.swift
@@ -19,7 +19,7 @@ enum CaptureTrigger {
 }
 
 /// Protocol to handle capture button user actions
-protocol ShootButtonViewDelegate: class {
+protocol ShootButtonViewDelegate: AnyObject {
 
     /// Function called when capture button was tapped
     func shootButtonViewDidTap()

--- a/Classes/Options/OptionsController.swift
+++ b/Classes/Options/OptionsController.swift
@@ -47,7 +47,7 @@ final class Option<Item> {
 }
 
 /// A protocol for handling selecting options
-protocol OptionsControllerDelegate: class {
+protocol OptionsControllerDelegate: AnyObject {
     associatedtype OptionsItem
 
     /// callback for selecting an option

--- a/Classes/Options/OptionsStackView.swift
+++ b/Classes/Options/OptionsStackView.swift
@@ -12,7 +12,7 @@ private struct OptionsStackViewConstants {
     static let inset: CGFloat = -15
 }
 
-protocol OptionsStackViewDelegate: class {
+protocol OptionsStackViewDelegate: AnyObject {
     /// callback for an option button being tapped
     func optionWasTapped(section: Int, optionIndex: Int)
 }

--- a/Classes/Preview/CameraPreviewView.swift
+++ b/Classes/Preview/CameraPreviewView.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// protocol for closing the preview or confirming
 
-protocol CameraPreviewViewDelegate: class {
+protocol CameraPreviewViewDelegate: AnyObject {
     /// A function that is called when the confirm button is pressed
     func confirmButtonPressed()
     /// A function that is called when the close button is pressed

--- a/Classes/Preview/CameraPreviewViewController.swift
+++ b/Classes/Preview/CameraPreviewViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Protocol for camera preview controller methods
 
-protocol CameraPreviewControllerDelegate: class {
+protocol CameraPreviewControllerDelegate: AnyObject {
     /// callback when finished exporting video clips.
     func didFinishExportingVideo(url: URL?)
 

--- a/Classes/Recording/CameraRecordingProtocol.swift
+++ b/Classes/Recording/CameraRecordingProtocol.swift
@@ -8,7 +8,7 @@ import AVFoundation
 import Foundation
 
 /// A protocol for camera recording callbacks
-protocol CameraRecordingDelegate: class {
+protocol CameraRecordingDelegate: AnyObject {
 
     /// this is called before a photo is taken. It uses the returned settings (if any) for the current device
     ///

--- a/Classes/Rendering/FilterProtocol.swift
+++ b/Classes/Rendering/FilterProtocol.swift
@@ -9,7 +9,7 @@ import Foundation
 import GLKit
 
 /// Protocol for filters
-protocol FilterProtocol: class {
+protocol FilterProtocol: AnyObject {
 
     /// Uses the sampleBuffer's dimensions to initialize framebuffers and pixel buffers.
     func setupFormatDescription(from sampleBuffer: CMSampleBuffer, transform: GLKMatrix4?, outputDimensions: CGSize)

--- a/Classes/Rendering/MediaExporter.swift
+++ b/Classes/Rendering/MediaExporter.swift
@@ -21,7 +21,7 @@ enum MediaExporterError: Error {
     case noProcessedImage
 }
 
-protocol MediaExporting: class {
+protocol MediaExporting: AnyObject {
     var filterType: FilterType { get set }
     var imageOverlays: [CGImage] { get set }
     init(settings: CameraSettings)

--- a/Classes/Rendering/MediaPlayer.swift
+++ b/Classes/Rendering/MediaPlayer.swift
@@ -12,7 +12,7 @@ import OpenGLES
 import GLKit
 
 /// Delegate for MediaPlayer
-protocol MediaPlayerDelegate: class {
+protocol MediaPlayerDelegate: AnyObject {
     /// Called then the first pixel buffer is shown
     /// - Parameter image: the first frame shown
     func didDisplayFirstFrame(_ image: UIImage)
@@ -21,7 +21,7 @@ protocol MediaPlayerDelegate: class {
 }
 
 /// Delegate for MediaPlayerView
-protocol MediaPlayerViewDelegate: class {
+protocol MediaPlayerViewDelegate: AnyObject {
     /// Called when the rendering rectangle changes
     /// - Parameter rect: new rendering rectangle
     func didRenderRectChange(rect: CGRect)

--- a/Classes/Rendering/OpenGL/GLPixelBufferView.swift
+++ b/Classes/Rendering/OpenGL/GLPixelBufferView.swift
@@ -11,7 +11,7 @@ import GLKit
 import os
 
 /// Protocol for GLPixelBufferView
-protocol GLPixelBufferViewDelegate: class {
+protocol GLPixelBufferViewDelegate: AnyObject {
 
     /// Called when the rendering rectangle changes
     func didRenderRectChange(rect: CGRect)

--- a/Classes/Rendering/PixelBufferView.swift
+++ b/Classes/Rendering/PixelBufferView.swift
@@ -7,7 +7,7 @@
 import Foundation
 import GLKit
 
-protocol PixelBufferView: class {
+protocol PixelBufferView: AnyObject {
     var mediaTransform: GLKMatrix4? { get set }
     var mediaContentMode: UIView.ContentMode { get }
     var isPortrait: Bool { get set }

--- a/Classes/Rendering/Renderer.swift
+++ b/Classes/Rendering/Renderer.swift
@@ -11,7 +11,7 @@ import OpenGLES
 import GLKit
 
 /// Callbacks for rendering
-protocol RendererDelegate: class {
+protocol RendererDelegate: AnyObject {
     /// Called when renderer has a processed pixel buffer ready for display. This may skip frames, so it's only
     /// intended to be used for display purposes.
     ///

--- a/Classes/Rendering/Rendering.swift
+++ b/Classes/Rendering/Rendering.swift
@@ -8,7 +8,7 @@ import Foundation
 import CoreMedia
 import GLKit
 
-protocol Rendering: class {
+protocol Rendering: AnyObject {
     var delegate: RendererDelegate? { get set }
     var filterPlatform: FilterPlatform { get set }
     var filterType: FilterType { get set }

--- a/Classes/Utility/EasyTipView.swift
+++ b/Classes/Utility/EasyTipView.swift
@@ -10,7 +10,7 @@
 import UIKit
 import Foundation
 
-public protocol EasyTipViewDelegate: class {
+public protocol EasyTipViewDelegate: AnyObject {
     func easyTipViewDidDismiss(_ tipView: EasyTipView)
 }
 

--- a/Classes/Utility/OptionSelector/OptionSelectorController.swift
+++ b/Classes/Utility/OptionSelector/OptionSelectorController.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for selecting an option.
-protocol OptionSelectorControllerDelegate: class {
+protocol OptionSelectorControllerDelegate: AnyObject {
     
     /// Called when an option is selected
     ///

--- a/Classes/Utility/OptionSelector/OptionSelectorView.swift
+++ b/Classes/Utility/OptionSelector/OptionSelectorView.swift
@@ -8,7 +8,7 @@ import Foundation
 import UIKit
 
 /// Protocol for tapping or swiping the options.
-protocol OptionSelectorViewDelegate: class {
+protocol OptionSelectorViewDelegate: AnyObject {
     
     /// Called when a cell is tapped
     ///

--- a/Example/KanvasExample.xcodeproj/xcshareddata/xcschemes/KanvasExample.xcscheme
+++ b/Example/KanvasExample.xcodeproj/xcshareddata/xcschemes/KanvasExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Removes xcode 14 deprecations alongside any new warnings that appear.
Two warnings remain which [seem to be down to xcode bugs](https://wpmobilep2.wordpress.com/2022/06/17/wordpress-ios-a-warning-free-project/#comment-6148).

These are all naming/syntactic changes that shouldn't impact the code in anyway. 🤞 


How to test:
🟢  CI