### PR TITLE
WIP- do not merge. [ICORE-4830] 

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -349,7 +349,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
             showPreviewWithSegments(segments, selected: segments.startIndex, edits: edits, animated: false)
             showPreview = false
         }
-        if delegate?.cameraShouldShowWelcomeTooltip() == true && cameraPermissionsViewController.hasFullAccess() {
+        if delegate?.cameraShouldShowWelcomeTooltip() == true && cameraPermissionsViewController.hasCameraAccess() {
             showWelcomeTooltip()
         }
     }
@@ -1081,8 +1081,12 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
         cameraZoomHandler.setZoom(gesture: gesture)
     }
 
-    func cameraInputControllerHasFullAccess() -> Bool {
-        return cameraPermissionsViewController.hasFullAccess()
+    func cameraInputControllerHasCameraAccess() -> Bool {
+        return cameraPermissionsViewController.hasCameraAccess()
+    }
+
+    func cameraInputControllerHasMicAccess() -> Bool {
+        return cameraPermissionsViewController.hasMicrophoneAccess()
     }
     
     // MARK: - FilterSettingsControllerDelegate
@@ -1113,8 +1117,15 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
 
     // MARK: - CameraPermissionsViewControllerDelegate
 
-    func cameraPermissionsChanged(hasFullAccess: Bool) {
-        if hasFullAccess {
+    func cameraPermissionsChanged(hasCameraAccess: Bool) {
+        if hasCameraAccess {
+            cameraInputController.setupCaptureSession()
+            toggleMediaPicker(visible: true, animated: false)
+        }
+    }
+
+    func micPermissionsChanged(hasMicAccess: Bool) {
+        if hasMicAccess {
             cameraInputController.setupCaptureSession()
             toggleMediaPicker(visible: true, animated: false)
         }
@@ -1133,7 +1144,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     ///   - animated: Whether to animate the transition.
     private func toggleMediaPicker(visible: Bool, animated: Bool = true) {
         if visible {
-            if !filterSettingsController.isFilterSelectorVisible() && cameraPermissionsViewController.hasFullAccess() {
+            if !filterSettingsController.isFilterSelectorVisible() && cameraPermissionsViewController.hasCameraAccess() {
                 modeAndShootController.showMediaPickerButton(basedOn: currentMode, animated: animated)
             }
             else {

--- a/Classes/Camera/CameraInputController.swift
+++ b/Classes/Camera/CameraInputController.swift
@@ -217,8 +217,8 @@ final class CameraInputController: UIViewController, CameraRecordingDelegate, AV
     func setupCaptureSession() {
         let frameSize = view.frame.size
         previewBlurView.effect = CameraInputController.blurEffect()
-        let hasFullAccess = delegate?.cameraInputControllerHasFullAccess() ?? true
-        guard hasFullAccess else {
+        let hasCameraAccess = delegate?.cameraInputControllerHasCameraAccess() ?? true
+        guard hasCameraAccess else {
             return
         }
         sessionQueue.async { [weak self] in
@@ -419,6 +419,10 @@ final class CameraInputController: UIViewController, CameraRecordingDelegate, AV
     /// - Returns: return true if successfully started recording
     func startRecording(on mode: CameraMode) -> Bool {
         guard let recorder = self.recorder else { return false }
+//        let hasMicAccess = delegate?.cameraInputControllerHasMicAccess() ?? true
+//        guard hasMicAccess else {
+//            return false
+//        }
         startAudioSession()
         addArtificialFlashIfNecessary()
         recorder.startRecordingVideo(on: mode)
@@ -596,8 +600,8 @@ final class CameraInputController: UIViewController, CameraRecordingDelegate, AV
             }
         }
         
-        let microphoneSession =  AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInMicrophone], mediaType: AVMediaType.audio, position: .unspecified)
-        microphone = microphoneSession.devices.first
+//        let microphoneSession =  AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInMicrophone], mediaType: AVMediaType.audio, position: .unspecified)
+//        microphone = microphoneSession.devices.first
     }
 
     /// Configures Camera Inputs. Must be called from the sessionQueue.
@@ -744,6 +748,15 @@ final class CameraInputController: UIViewController, CameraRecordingDelegate, AV
 
     func cameraWillTakeVideo() {
         guard let camera = currentDevice else { return }
+
+        // check for microphone access
+        let microphoneSession =  AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInMicrophone], mediaType: AVMediaType.audio, position: .unspecified)
+        microphone = microphoneSession.devices.first
+        let hasMicAccess = delegate?.cameraInputControllerHasMicAccess() ?? true
+        guard hasMicAccess else {
+            return
+        }
+
         if flashMode == .on {
             if camera.hasTorch && camera.isTorchModeSupported(.on) {
                 do {

--- a/Classes/Camera/CameraInputControllerDelegate.swift
+++ b/Classes/Camera/CameraInputControllerDelegate.swift
@@ -17,5 +17,7 @@ protocol CameraInputControllerDelegate: AnyObject {
     ///   - gesture: the pinch gesture
     func cameraInputControllerPinched(gesture: UIPinchGestureRecognizer)
 
-    func cameraInputControllerHasFullAccess() -> Bool
+    func cameraInputControllerHasCameraAccess() -> Bool
+
+    func cameraInputControllerHasMicAccess() -> Bool
 }

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -27,7 +27,9 @@ protocol CameraPermissionsViewDelegate: AnyObject {
 
 protocol CameraPermissionsViewControllerDelegate: AnyObject {
 
-    func cameraPermissionsCameraChanged(hasCameraAccess: Bool)
+    func cameraPermissionsChanged(hasCameraAccess: Bool)
+
+    func micPermissionsChanged(hasMicAccess: Bool)
 
     func openAppSettings(completion: ((Bool) -> ())?)
 }
@@ -225,6 +227,7 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
 
         setupViewFromAccess()
         if hasCameraAccess() { return }
+        
         requestCameraAccess()
     }
     
@@ -262,11 +265,17 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         delegate?.openAppSettings(completion: nil)
     }
 
-    func hasCameraAccessOnly() -> Bool {
-        hasCameraAccess()
+    // public accessor
+    func hasCameraAccess() -> Bool {
+        hasCameraAuthorized()
     }
 
-    private func hasCameraAccess() -> Bool {
+    // public acessor
+    func hasMicrophoneAccess() -> Bool {
+        hasMicrophoneAuthorized()
+    }
+
+    private func hasCameraAuthorized() -> Bool {
         switch captureDeviceAuthorizer.authorizationStatus(for: .video) {
         case .notDetermined, .restricted, .denied:
             return false
@@ -277,7 +286,7 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         }
     }
 
-    private func hasMicrophoneAccess() -> Bool {
+    private func hasMicrophoneAuthorized() -> Bool {
         switch captureDeviceAuthorizer.authorizationStatus(for: .audio) {
         case .notDetermined, .restricted, .denied:
             return false
@@ -290,7 +299,7 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
 
     private func setupViewFromAccessAndNotifyPermissionsChanged() {
         setupViewFromAccess()
-        delegate?.cameraPermissionsCameraChanged(hasCameraAccess: self.hasCameraAccess())
+        delegate?.cameraPermissionsChanged(hasCameraAccess: self.hasCameraAccess())
     }
 
     private func setupViewFromAccess() {

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -227,6 +227,7 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         if hasFullAccess() { return }
         
         requestCameraAccess()
+        requestMicrophoneAccess()
     }
     
     func requestCameraAccess() {
@@ -235,7 +236,6 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
             captureDeviceAuthorizer.requestAccess(for: .video) { videoGranted in
                 performUIUpdate {
                     self.setupViewFromAccessAndNotifyPermissionsChanged()
-                    self.requestMicrophoneAccess()
                 }
             }
         case .restricted, .denied, .authorized:

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -27,7 +27,7 @@ protocol CameraPermissionsViewDelegate: AnyObject {
 
 protocol CameraPermissionsViewControllerDelegate: AnyObject {
 
-    func cameraPermissionsChanged(hasFullAccess: Bool)
+    func cameraPermissionsCameraChanged(hasCameraAccess: Bool)
 
     func openAppSettings(completion: ((Bool) -> ())?)
 }
@@ -224,10 +224,8 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         super.viewWillAppear(animated)
 
         setupViewFromAccess()
-        if hasFullAccess() { return }
-        
+        if hasCameraAccess() { return }
         requestCameraAccess()
-        requestMicrophoneAccess()
     }
     
     func requestCameraAccess() {
@@ -264,8 +262,8 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         delegate?.openAppSettings(completion: nil)
     }
 
-    func hasFullAccess() -> Bool {
-        return hasCameraAccess() && hasMicrophoneAccess()
+    func hasCameraAccessOnly() -> Bool {
+        hasCameraAccess()
     }
 
     private func hasCameraAccess() -> Bool {
@@ -292,11 +290,11 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
 
     private func setupViewFromAccessAndNotifyPermissionsChanged() {
         setupViewFromAccess()
-        delegate?.cameraPermissionsChanged(hasFullAccess: self.hasFullAccess())
+        delegate?.cameraPermissionsCameraChanged(hasCameraAccess: self.hasCameraAccess())
     }
 
     private func setupViewFromAccess() {
-        if hasFullAccess() {
+        if hasCameraAccess() {
             showIgnoreTouchesView()
         }
         else {

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -227,7 +227,6 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
         if hasFullAccess() { return }
         
         requestCameraAccess()
-        requestMicrophoneAccess()
     }
     
     func requestCameraAccess() {
@@ -236,6 +235,7 @@ class CameraPermissionsViewController: UIViewController, CameraPermissionsViewDe
             captureDeviceAuthorizer.requestAccess(for: .video) { videoGranted in
                 performUIUpdate {
                     self.setupViewFromAccessAndNotifyPermissionsChanged()
+                    self.requestMicrophoneAccess()
                 }
             }
         case .restricted, .denied, .authorized:


### PR DESCRIPTION
[ICORE-4830] Move request for access to the microphone to prompt after video camera

## Summary

Previously, we displayed the prompt to access the microphone right after displaying the prompt to access the camera. This is confusing because the user is not attempting to record video. They are taking a picture. 

This PR changes the timing of the prompt to happen after the user accesses the video camera, and after the request to access the video camera has been asked first.

## Testing instructions

WIP, do not merge
