### PR TITLE
[ICORE-5154] Fix crash when accessing viewControllers in array

### DIFF
--- a/Example/KanvasExample/SplitViewController.swift
+++ b/Example/KanvasExample/SplitViewController.swift
@@ -189,7 +189,7 @@ extension SplitViewController: UIPageViewControllerDataSource {
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         if let index = orderedViewControllers.firstIndex(of: viewController) {
             let nextIndex = orderedViewControllers.index(after: index)
-            if orderedViewControllers.endIndex >= nextIndex {
+            if orderedViewControllers.indices.contains(nextIndex) {
                 let nextVC = orderedViewControllers[nextIndex]
                 return nextVC
             }


### PR DESCRIPTION
## Summary

When running the sample app, there is a crash when swiping on the `MockDashboardViewController`. 

## Steps to test fix:

1. `pod install` on the sample app and open the .xcworkspace
2. run on a simulator
3. grant access to camera and microphone when prompted
4. close kanvas
5. use the text button that says "Open Kanvas Dashboard" 
6. swipe left on kanvas
7. swipe left on kanvas
8. (should not crash after second swipe left)
