### PR TITLE
Multiple exports: Deleting one image causes the next one not to load in the editor

### DIFF
--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -147,6 +147,8 @@ class MultiEditorViewController: UIViewController {
                 self?.clipsController.removeDraggingClip()
             }
             load(childViewController: editor, into: editorContainer)
+            editorContainer.layoutIfNeeded()
+
             if current {
                 currentEditor = editor
             } else {

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -147,7 +147,6 @@ class MultiEditorViewController: UIViewController {
                 self?.clipsController.removeDraggingClip()
             }
             load(childViewController: editor, into: editorContainer)
-
             if current {
                 currentEditor = editor
             } else {

--- a/Classes/Editor/MultiEditor/MultiEditorViewController.swift
+++ b/Classes/Editor/MultiEditor/MultiEditorViewController.swift
@@ -147,7 +147,6 @@ class MultiEditorViewController: UIViewController {
                 self?.clipsController.removeDraggingClip()
             }
             load(childViewController: editor, into: editorContainer)
-            editorContainer.layoutIfNeeded()
 
             if current {
                 currentEditor = editor
@@ -229,6 +228,9 @@ extension MultiEditorViewController: MediaClipsEditorDelegate {
         if selected == nil {
             dismissButtonPressed()
         }
+        
+        /// The editor does not layout automatically after we delete a clip and load another image
+        editorContainer.layoutIfNeeded()
     }
     
     func mediaClipWasAdded(at index: Int) {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kanvas (1.4.3)
+  - Kanvas (1.4.4)
 
 DEPENDENCIES:
   - iOSSnapshotTestCase (= 8.0.0)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kanvas: 6355398addfc9856c27cc780cbf54df7cd822ab1
+  Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
 
 PODFILE CHECKSUM: fdc53cacfa7ab03ea306122ff8e788755ac41de3
 

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.4.3'
+  spec.version      = '1.4.4'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
## Description

Deleting one image causes the next one not to load in the editor.
Issue found in https://github.com/wordpress-mobile/WordPress-iOS/issues/16966 but can also be reproducible on the example app

## Solution

I found the issue to be related to layout updates.

When `mediaClipWasDeleted` in `MultiEditorViewController` is called, we set the new selection `selected = newSelection` which in turns call `loadEditor` method. 
Normally, after `load(childVIewController:into)` is called the selected image is loaded. However, when the previous image is deleted, the editor does not layout automatically and the image does not appear.

`load(childVIewController:into)` itself is implemented [using recommended patterns](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/ImplementingaContainerViewController.html) and works in other cases in this library. 

I decided to ask for layout updates only in the case when we load the editor. 

## Testing instructions

### Case 1:
1. Launch example app
2. Enable "Multiple exports"
3. Make / Select multiple photos
4. Delete one of the images
5. Another picture should load

## Images & Videos

### Before

https://user-images.githubusercontent.com/4062343/190409311-92428eba-fd50-4744-bf72-8484adb2e632.MP4

### After

https://user-images.githubusercontent.com/4062343/190409273-7376dbae-df01-4123-8375-b78a87ab940e.MP4







