### PR TITLE
Bump up version to 1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,12 @@ _None._
 
 -->
 
-## Unreleased
+## 1.4.6
 
 - Fixes issues with files missing imports. [#149]
 - Adds Crop & Rotate capabilities to the editor. [#150]
+
+## Unreleased
 
 ### Breaking Changes
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kanvas (1.4.5):
+  - Kanvas (1.4.6):
     - CropViewController
 
 DEPENDENCIES:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CropViewController: 58fb440f30dac788b129d2a1f24cffdcb102669c
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kanvas: ba3776ac11e5ce017ecc3e12b37a6ed34268ea0d
+  Kanvas: d484755bd7a2a593dd9b935240a8bc4a54776856
 
 PODFILE CHECKSUM: 7f87a0c75f7e07c253792681a758e25d03b1f121
 

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.4.5'
+  spec.version      = '1.4.6'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
This PR updates the podspec version of kanvas and the changelog.

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
