### PR TITLE
Make the crop box swap its dimensions depending on portrait/landscape images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ _None._
 
 -->
 
+## 1.4.7
+
+- The crop box starts to swap its dimensions depending on portrait or landscape sized images. [#152]
+
 ## 1.4.6
 
 - Fixes issues with files missing imports. [#149]

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -1071,6 +1071,7 @@ public final class EditorViewController: UIViewController, MediaPlayerController
             return
         }
         let cropViewController = CropViewController(image: image)
+        cropViewController.aspectRatioLockDimensionSwapEnabled = true
         cropViewController.delegate = self
         cropRotateApplied = false
         present(cropViewController, animated: true, completion: nil)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kanvas (1.4.6):
+  - Kanvas (1.4.7):
     - CropViewController
 
 DEPENDENCIES:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CropViewController: 58fb440f30dac788b129d2a1f24cffdcb102669c
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kanvas: d484755bd7a2a593dd9b935240a8bc4a54776856
+  Kanvas: 78ab35b53e9bd8e4233f042bcadf76b3ca2022e5
 
 PODFILE CHECKSUM: 7f87a0c75f7e07c253792681a758e25d03b1f121
 

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.4.6'
+  spec.version      = '1.4.7'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
This PR sets aspectRatioLockDimensionSwapEnabled to `true` on the crop controller which makes the crop box swap its dimensions depending on portrait/landscape images. This fixes a recently reported issue where cropped image shifts during rotating 180 degrees.

# To test

- cd kanvas-ios/Example
- bundle exec pod install
- Run the example app
- If you are on the Sim make sure to enable metal related switches
- Select an image
- Tap on the crop & rotate icon
- Tap on the crop presets and select the square preset 
- Rotate the image 180 degrees
- Observe that the cropped area doesn't change

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
