### PR TITLE
Replace DispatchQueue.global by Swift concurrency

### DIFF
--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -1002,7 +1002,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
                 }
             }
             
-            let archiver = MediaArchiver(saveDirectory: saveDirectory)
+            let archiver = MediaArchiver(saveDirectory: self.saveDirectory)
             let publishers = archiver.handle(exports: exports)
             
             self.exportCancellable = publishers.receive(on: DispatchQueue.main).sink { completion in

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -991,7 +991,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     
     private func exportingDidFinishHandler(from result: [Result<EditorViewController.ExportResult, Error>]) async {
         Task { [weak self] in
-            guard let self else { return }
+            guard let self = self else { return }
             
             let exports: [EditorViewController.ExportResult?] = result.map { result in
                 switch result {

--- a/Classes/Camera/MediaArchiver.swift
+++ b/Classes/Camera/MediaArchiver.swift
@@ -31,7 +31,7 @@ class MediaArchiver {
             return Future { [weak self] promise in
                 guard let self else { return }
                 
-                Task.detached(priority: .background) { [weak self] in
+                Task.detached(priority: .userInitiated) { [weak self] in
                     guard let export else {
                         promise(.success((index, nil)))
                         return

--- a/Classes/Camera/MediaArchiver.swift
+++ b/Classes/Camera/MediaArchiver.swift
@@ -29,10 +29,10 @@ class MediaArchiver {
         let exportCount = exports.count
         let publishers: [AnyPublisher<(Int, KanvasMedia?), Error>] = exports.enumerated().map { (index, export) in
             return Future { [weak self] promise in
-                guard let self else { return }
+                guard let self = self else { return }
                 
                 Task.detached(priority: .userInitiated) { [weak self] in
-                    guard let export else {
+                    guard let export = export else {
                         promise(.success((index, nil)))
                         return
                     }

--- a/Classes/Camera/MediaArchiver.swift
+++ b/Classes/Camera/MediaArchiver.swift
@@ -15,7 +15,6 @@ class MediaArchiver {
     let saveDirectory: URL?
 
     private let log = OSLog(subsystem: "com.tumblr.kanvas", category: "MediaArchiver")
-    private let dispatchQueue = DispatchQueue.global(qos: .userInitiated)
 
     /// Initializes a new MediaArchiver class to handle exports.
     /// - Parameter saveDirectory: A URL to save the files to.
@@ -29,16 +28,20 @@ class MediaArchiver {
     func handle(exports: [EditorViewController.ExportResult?]) -> AnyPublisher<CameraController.MediaOutput, Error> {
         let exportCount = exports.count
         let publishers: [AnyPublisher<(Int, KanvasMedia?), Error>] = exports.enumerated().map { (index, export) in
-            return dispatchQueue.publisher { [weak self] promise
-                in
-                guard let export = export else {
-                    promise(.success((index, nil)))
-                    return
+            return Future { [weak self] promise in
+                guard let self else { return }
+                
+                Task.detached(priority: .background) { [weak self] in
+                    guard let export else {
+                        promise(.success((index, nil)))
+                        return
+                    }
+                    let media = self?.handle(export: export)
+                    promise(.success((index, media)))
                 }
-                let media = self?.handle(export: export)
-                promise(.success((index, media)))
-            }
+            }.eraseToAnyPublisher()
         }
+        
         let allPublishers = Publishers.MergeMany(publishers)
         let collected = allPublishers.collect(exportCount).sort(by: { (first, second) in
             return first.0 < second.0
@@ -126,17 +129,6 @@ extension UIImage {
             print("Failed to save to file. \(error)")
             return nil
         }
-    }
-}
-
-private extension DispatchQueue {
-
-    /// Dispatches `block` asynchronously.
-    /// - Parameter block: Block
-    func publisher<Output, Failure: Error>(_ block: @escaping (Future<Output, Failure>.Promise) -> Void) -> AnyPublisher<Output, Failure> {
-        Future<Output, Failure> { promise in
-            self.async { block(promise) }
-        }.eraseToAnyPublisher()
     }
 }
 

--- a/Classes/Rendering/MediaExporter.swift
+++ b/Classes/Rendering/MediaExporter.swift
@@ -53,10 +53,17 @@ final class MediaExporter: MediaExporting {
         return true
     }
     
+    /// A Task to control exportFrames task, it need to be canceld when MediaExporter is deallocated
+    private var exportFramesTask: Task<Void, Error>?
+    
     private let settings: CameraSettings
     
     init(settings: CameraSettings) {
         self.settings = settings
+    }
+    
+    deinit {
+        exportFramesTask?.cancel()
     }
 
     /// Exports an image
@@ -90,10 +97,16 @@ final class MediaExporter: MediaExporting {
             completion(processedImage, nil)
         }
     }
-
+    
     func export(frames: [MediaFrame], toSize: CGSize?, completion: @escaping ([MediaFrame]) -> Void) {
-        var processedFrames: [MediaFrame] = []
-        DispatchQueue.global(qos: .default).async {
+        
+        exportFramesTask = Task.detached(priority: .medium) { [weak self] in
+            guard let self else {
+                completion([])
+                return
+            }
+            
+            var processedFrames: [MediaFrame] = []
             var time: TimeInterval = 0
             for frame in frames {
                 autoreleasepool {
@@ -106,7 +119,8 @@ final class MediaExporter: MediaExporting {
                     }
                 }
             }
-            DispatchQueue.main.async {
+            
+            await MainActor.run { [processedFrames] in
                 completion(processedFrames)
             }
         }

--- a/Classes/Rendering/MediaExporter.swift
+++ b/Classes/Rendering/MediaExporter.swift
@@ -100,12 +100,7 @@ final class MediaExporter: MediaExporting {
     
     func export(frames: [MediaFrame], toSize: CGSize?, completion: @escaping ([MediaFrame]) -> Void) {
         
-        exportFramesTask = Task.detached(priority: .medium) { [weak self] in
-            guard let self else {
-                completion([])
-                return
-            }
-            
+        exportFramesTask = Task.detached(priority: .medium) {
             var processedFrames: [MediaFrame] = []
             var time: TimeInterval = 0
             for frame in frames {


### PR DESCRIPTION
- `DispatchQueue.global` usage could lead to thread explosion. This PR is to replace it by using Swift concurrency.
- Upgrade Xcode version to 14.3

### Testing
- Enable the `Multiple Exports`
- Add multiple images
- Confirm then tap Post button
- **Expected**: The app should work normally.