### PR TITLE
Fix streched GIF image issue

### DIFF
--- a/Classes/Camera/CameraInputController.swift
+++ b/Classes/Camera/CameraInputController.swift
@@ -550,8 +550,10 @@ final class CameraInputController: UIViewController, CameraRecordingDelegate, AV
         if let formatDescription = currentDevice?.activeFormat.formatDescription {
             let videoDimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
             var dimensions = CGSize(width: CGFloat(videoDimensions.height), height: CGFloat(videoDimensions.width))
-            // Make recording resolution have the same aspect ratio as the screen
-            dimensions.width = dimensions.height * (frameSize.width / frameSize.height)
+            if settings.features.scaleMediaToFill {
+                // Make recording resolution have the same aspect ratio as the screen
+                dimensions.width = dimensions.height * (frameSize.width / frameSize.height)
+            }
             return dimensions
         }
         return .zero


### PR DESCRIPTION
### Problem

- Image becomes stretched after taking a shot in GIF mode.

### Why

In `scaleMediaToFill = true` mode, this [logic](https://github.com/tumblr/kanvas-ios/blob/1496390be9feceb73ee8c056a722df0a0e4db116/Classes/Rendering/Renderer.swift#L224) will be applied for the **width**.

```
inputDimensions.height * (scaleToFillSize.width / scaleToFillSize.height)
```

But in the current code, the same logic still applies [here](https://github.com/tumblr/kanvas-ios/blob/1496390be9feceb73ee8c056a722df0a0e4db116/Classes/Camera/CameraInputController.swift#LL554C7-L554C7) when calculating `recordingDimensions`

```
// Make recording resolution have the same aspect ratio as the screen
dimensions.width = dimensions.height * (frameSize.width / frameSize.height)
```

So this should cause the mismatched logic, then making the GIF image stretched because the `width` has been wrong calculated.

### The Fix

I added the condition to apply the change of `width` in the case of `scaleMediaToFill == true`.

## How to test
Run `Example` project, and take a shot in GIF mode. **Expected:** the image after taking a shot should not be stretched. 

