### PR TITLE
Encode gif if CameraMode is set to GIF

### DIFF
--- a/Classes/Preview/CameraPreviewViewController.swift
+++ b/Classes/Preview/CameraPreviewViewController.swift
@@ -294,8 +294,7 @@ extension CameraPreviewViewController: CameraPreviewViewDelegate {
             case .video(let videoURL, _):
                 // If the camera mode is .stopMotion, .normal or .stitch (.video) and the `exportStopMotionPhotoAsVideo` is true,
                 // then single photos from that mode should still export as video.
-                if settings.features.gifs,
-                   let group = cameraMode?.group, group == .gif {
+                if let group = cameraMode?.group, group == .gif {
                     gifEncoder.encode(video: videoURL,
                                       loopCount: 0,
                                       framesPerSecond: KanvasTimes.gifPreferredFramesPerSecond) { gifURL in

--- a/Classes/Preview/CameraPreviewViewController.swift
+++ b/Classes/Preview/CameraPreviewViewController.swift
@@ -294,7 +294,7 @@ extension CameraPreviewViewController: CameraPreviewViewDelegate {
             case .video(let videoURL, _):
                 // If the camera mode is .stopMotion, .normal or .stitch (.video) and the `exportStopMotionPhotoAsVideo` is true,
                 // then single photos from that mode should still export as video.
-                if let group = cameraMode?.group, group == .gif {
+                if cameraMode?.group == .gif {
                     gifEncoder.encode(video: videoURL,
                                       loopCount: 0,
                                       framesPerSecond: KanvasTimes.gifPreferredFramesPerSecond) { gifURL in

--- a/Example/KanvasExampleTests/CameraPreview/CameraPreviewControllerTests.swift
+++ b/Example/KanvasExampleTests/CameraPreview/CameraPreviewControllerTests.swift
@@ -74,8 +74,7 @@ final class CameraPreviewControllerTests: FBSnapshotTestCase {
         let handler = assetsHandler ?? AssetsHandlerStub()
         let viewController = CameraPreviewViewController(settings: settings,
                                                          segments: segments,
-                                                         assetsHandler:
-                                                            handler,
+                                                         assetsHandler: handler,
                                                          cameraMode: cameraMode,
                                                          gifEncoder: gifEncoder)
         viewController.delegate = delegate ?? newDelegateStub()


### PR DESCRIPTION
## What it does

GIFs sometimes aren't encoded when the CameraMode is set to gif. This is as there's a `settings.feature.gifs` flag we check that determines if gifs should be enabled.

It's possible to use the API to trigger a CameraViewController on gif mode without having this feature on. This is [a bug](https://github.com/tumblr/kanvas-ios/issues/160) in itself but for the time being this PR ensures that if a user has selected the gif camera and taken a photo we always encode that gif. Prior to now the gif was coming out as a video.

I've made this function testable and added a test. The commit with the actual functionality change is below:
[The fix commit](https://github.com/tumblr/kanvas-ios/pull/159/commits/a66a7e4179d588fcd6deef88f3dcf3461eefa158)

## How to test

Use a real device for both tests

### Example project

* Load the example project on to a real device
* Disable gif support
* Change the camera to gif mode
* Take a photo and post
* You should be brought back to the dashboard
* Repeat this 4-5 times to check we don't crash or freeze

### Tumblr Integration
 
[Test instructions + JIRA Ticket](https://github.tumblr.net/TumblrMobile/orangina/pull/25164)

## Etc

CC: @bjtitus I'd like your eyes on [the fix commit](https://github.com/tumblr/kanvas-ios/pull/159/commits/a66a7e4179d588fcd6deef88f3dcf3461eefa158). I'm making what I think to be a safe assumption that we'd always want to encode a gif once the user has set the camera to gif mode. If this isn't the case I may need to expand this PR to [prevent us getting to this state in the first place](https://github.com/tumblr/kanvas-ios/issues/160)

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
