### PR TITLE
Upgrade Kanvas to 1.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,15 @@ _None._
 
 -->
 
-## Unreleased
+## 1.4.9
 
-- Added new delegate methods to track appearing and disappearing of camera, preview, and editor screens. [#156]
+- Force any video to encode as a gif when taken with the gif camera [#159]
 
 ## 1.4.8
 
 - Replace `DispatchQueue.global` with Swift concurrency to reduce Thread Explosion [#153]
 - Fix streched image after taking a shot in GIF mode issue [#155]
+- Add new delegate methods to track appearing and disappearing of camera, preview, and editor screens. [#156]
 
 ## 1.4.7
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kanvas (1.4.8):
+  - Kanvas (1.4.9):
     - CropViewController
 
 DEPENDENCIES:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CropViewController: 58fb440f30dac788b129d2a1f24cffdcb102669c
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kanvas: c4983081eccd9ac190799989a54a57fd08bd0092
+  Kanvas: cc027f8058de881a4ae2b5aa5f05037b6d054d08
 
 PODFILE CHECKSUM: 7f87a0c75f7e07c253792681a758e25d03b1f121
 

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.4.8'
+  spec.version      = '1.4.9'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
Updates Kanvas version, example project and change log to 1.4.9

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
