### PR TITLE
Fix iOS 18 cell dequeue crash

### DIFF
--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -508,14 +508,10 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     // MARK: - GIF Maker Helpers
 
     private func openGIFMaker(animated: Bool) {
-        guard let cell = collectionController.getCell(for: .gif) else {
-            assertionFailure("Failed to open GIF Maker")
-            return
-        }
-        openGIFMaker(cell: cell, animated: animated, permanent: true)
+        openGIFMaker(cell: collectionController.getCell(for: .gif), animated: animated, permanent: true)
     }
 
-    private func openGIFMaker(cell: KanvasEditorMenuCollectionCell, animated: Bool, permanent: Bool) {
+    private func openGIFMaker(cell: KanvasEditorMenuCollectionCell?, animated: Bool, permanent: Bool) {
         let editionOption = EditionOption.gif
         onBeforeShowingEditionMenu(editionOption, cell: cell)
         showMainUI(false)

--- a/Classes/Editor/Menu/EditionMenu/EditionMenuCollectionController.swift
+++ b/Classes/Editor/Menu/EditionMenu/EditionMenuCollectionController.swift
@@ -112,7 +112,7 @@ final class EditionMenuCollectionController: UIViewController, KanvasEditorMenuC
             return nil
         }
         let indexPath = IndexPath(item: index, section: Constants.section)
-        return self.collectionView(collectionView, cellForItemAt: indexPath) as? EditionMenuCollectionCell
+        return collectionView.cellForItem(at: indexPath) as? EditionMenuCollectionCell
     }
     
     // MARK: - UICollectionViewDataSource


### PR DESCRIPTION
A crash occurs on iOS when trying to call on `dequeueReusableCell` method when it isn't used for display.

This PR changes the method used to `cellForItem(at:)` instead to prevent crash. (Apple logs specifically mentions the improper use of `dequeue`)

While we are at it, the returned `cell` was passed to a non optional parameter, but all future uses of it was optional.
Turn the parameter to optional, and remove the `assertFailure` to make the application more resistant to crashes.