### PR TITLE
Localized strings update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ _None._
 
 -->
 
+## 1.5.2
+
+- Updates localized strings to be compatible with genstrings tool. [#168]
+
+## 1.5.1
+
+- Fixes a crash on iOS 18. [#167]
+
 ## 1.5.0
 
 - Adds support for Swift Package Manager [#166]

--- a/Classes/Camera/CameraController.swift
+++ b/Classes/Camera/CameraController.swift
@@ -480,9 +480,9 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     }
     
     private func showDismissTooltip() {
-        let alertController = UIAlertController(title: nil, message: NSLocalizedString("Are you sure? If you close this, you'll lose everything you just created.", comment: "Popup message when user discards all their clips"), preferredStyle: .alert)
-        let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert controller"), style: .cancel)
-        let discardAction = UIAlertAction(title: NSLocalizedString("I'm sure", comment: "Confirmation to discard all the clips"), style: .destructive) { [weak self] (UIAlertAction) in
+        let alertController = UIAlertController(title: nil, message: NSLocalizedString("Are you sure? If you close this, you'll lose everything you just created.", value: "Are you sure? If you close this, you'll lose everything you just created.", comment: "Popup message when user discards all their clips"), preferredStyle: .alert)
+        let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", value: "Cancel", comment: "Cancel alert controller"), style: .cancel)
+        let discardAction = UIAlertAction(title: NSLocalizedString("I'm sure", value: "I'm sure", comment: "Confirmation to discard all the clips"), style: .destructive) { [weak self] (UIAlertAction) in
             self?.handleCloseButtonPressed()
         }
         alertController.addAction(cancelAction)
@@ -1275,7 +1275,7 @@ open class CameraController: UIViewController, MediaClipsEditorDelegate, CameraP
     }
 
     public func pickingMediaNotAllowed(reason: String) {
-        let buttonMessage = NSLocalizedString("Got it", comment: "Got it")
+        let buttonMessage = NSLocalizedString("Got it", value: "Got it", comment: "Got it")
         showAlert(message: reason, buttonMessage: buttonMessage)
     }
 

--- a/Classes/Camera/CameraPermissionsViewController.swift
+++ b/Classes/Camera/CameraPermissionsViewController.swift
@@ -84,8 +84,8 @@ class CameraPermissionsView: UIView {
     }()
 
     lazy var settingsButton: UIButton = {
-        let title = NSLocalizedString("PhotoAccessNoAccessAction", comment: "PhotoAccessNoAccessAction")
-        let titleDisabled = NSLocalizedString("PhotoAccessNoAccessAction", comment: "PhotoAccessNoAccessAction")
+        let title = NSLocalizedString("PhotoAccessNoAccessAction", value: "Take me to Settings", comment: "Action button text for scenerio when access to Photos has been disallowed")
+        let titleDisabled = NSLocalizedString("PhotoAccessNoAccessAction", value: "Take me to Settings", comment: "Action button text for scenerio when access to Photos has been disallowed")
         let button = CameraPermissionsView.makeButton(title: title, titleDisabled: titleDisabled)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(openAppSettings), for: .touchUpInside)

--- a/Classes/Constants/KanvasStrings.swift
+++ b/Classes/Constants/KanvasStrings.swift
@@ -11,22 +11,22 @@ public struct KanvasStrings {
     // MARK: - Camera Modes
 
     // photoModeName: used in the camera mode button
-    static let photoModeName: String = NSLocalizedString("Photo", comment: "Photo camera mode")
+    static let photoModeName: String = NSLocalizedString("Photo", value: "Photo", comment: "Photo camera mode")
 
     // loopModeName: used in the camera mode button
-    static let loopModeName: String = NSLocalizedString("Loop", comment: "Gif camera mode")
+    static let loopModeName: String = NSLocalizedString("Loop", value: "Loop", comment: "Gif camera mode")
 
     // stopMotionModeName: used in the camera mode button
-    static let stopMotionModeName: String = NSLocalizedString("Capture", comment: "Stop motion camera mode")
+    static let stopMotionModeName: String = NSLocalizedString("Capture", value: "Capture", comment: "Stop motion camera mode")
     
     // normalModeName: used in the camera mode button
-    static let normalModeName: String = NSLocalizedString("Normal", comment: "Normal camera mode")
+    static let normalModeName: String = NSLocalizedString("Normal", value: "Normal", comment: "Normal camera mode")
     
     // stitchModeName: used in the camera mode button
-    static let stitchModeName: String = NSLocalizedString("Stitch", comment: "Stitch camera mode")
+    static let stitchModeName: String = NSLocalizedString("Stitch", value: "Stitch", comment: "Stitch camera mode")
     
     // gifModeName: used in the camera mode button
-    static let gifModeName: String = NSLocalizedString("GIF", comment: "GIF camera mode")
+    static let gifModeName: String = NSLocalizedString("GIF", value: "GIF", comment: "GIF camera mode")
     
     static func name(for mode: CameraMode) -> String {
         switch mode {

--- a/Classes/Editor/EditorView.swift
+++ b/Classes/Editor/EditorView.swift
@@ -699,7 +699,7 @@ final class EditorView: UIView, MovableViewCanvasDelegate, MediaPlayerViewDelega
             postButton.bottomAnchor.constraint(equalTo: safeLayoutGuide.bottomAnchor, constant: -EditorViewConstants.postButtonVerticalMargin)
         ])
         
-        postLabel.text = NSLocalizedString("Post", comment: "Message for the post button in the editor screen")
+        postLabel.text = NSLocalizedString("Post", value: "Post", comment: "Message for the post button in the editor screen")
         postLabel.textColor = .white
         postLabel.font = KanvasFonts.shared.postLabelFont
         postLabel.clipsToBounds = false

--- a/Classes/Editor/EditorViewController.swift
+++ b/Classes/Editor/EditorViewController.swift
@@ -950,9 +950,9 @@ public final class EditorViewController: UIViewController, MediaPlayerController
     private func handleExportError() {
         delegate?.didFailExporting()
         let alertController = UIAlertController(title: nil,
-                                                message: NSLocalizedString("SomethingGoofedTitle", comment: "Alert controller message"),
+                                                message: NSLocalizedString("SomethingGoofedTitle", value: "Something goofed.", comment: "Alert controller message"),
                                                 preferredStyle: .alert)
-        let tryAgainButton = UIAlertAction(title: NSLocalizedString("Try again", comment: "Try creating final content again"), style: .default) { _ in
+        let tryAgainButton = UIAlertAction(title: NSLocalizedString("Try again", value: "Try again", comment: "Try again"), style: .default) { _ in
             alertController.dismiss(animated: true, completion: .none)
         }
         alertController.addAction(tryAgainButton)

--- a/Classes/Editor/GIFMaker/Playback/PlaybackOption.swift
+++ b/Classes/Editor/GIFMaker/Playback/PlaybackOption.swift
@@ -17,11 +17,11 @@ enum PlaybackOption: String, OptionSelectorItem {
     var description: String {
         switch self {
         case .loop:
-            return NSLocalizedString("GIFLoop", comment: "Loop playback mode")
+            return NSLocalizedString("GIFLoop", value: "Loop", comment: "Loop playback mode")
         case .rebound:
-            return NSLocalizedString("GIFRebound", comment: "Rebound playback mode")
+            return NSLocalizedString("GIFRebound", value: "Rebound", comment: "Rebound playback mode")
         case .reverse:
-            return NSLocalizedString("GIFReverseLoop", comment: "Reverse playback mode")
+            return NSLocalizedString("GIFReverseLoop", value: "Reverse", comment: "Reverse playback mode")
         }
     }
     

--- a/Classes/Editor/Media/TabBar/DrawerTabBarOption.swift
+++ b/Classes/Editor/Media/TabBar/DrawerTabBarOption.swift
@@ -12,7 +12,7 @@ enum DrawerTabBarOption: String {
     var description: String {
         switch self {
         case .stickers:
-            return NSLocalizedString("Stickers", comment: "Stickers tab text in media drawer")
+            return NSLocalizedString("Stickers", value: "Stickers", comment: "Stickers tab text in media drawer")
         }
     }
 }

--- a/Classes/Editor/Menu/Shared/EditionOption.swift
+++ b/Classes/Editor/Menu/Shared/EditionOption.swift
@@ -18,17 +18,17 @@ enum EditionOption: Int {
     var text: String {
         switch self {
         case .gif:
-            return NSLocalizedString("EditorGIF", comment: "Label for the GIF option in the editor tools")
+            return NSLocalizedString("EditorGIF", value: "Create GIF", comment: "Label for the GIF option in the editor tools")
         case .filter:
-            return NSLocalizedString("EditorFilters", comment: "Label for the filters option in the editor tools")
+            return NSLocalizedString("EditorFilters", value: "Filters", comment: "Label for the filters option in the editor tools")
         case .text:
-            return NSLocalizedString("EditorText", comment: "Label for the text option in the editor tools")
+            return NSLocalizedString("EditorText", value: "Text", comment: "Label for the text option in the editor tools")
         case .media:
-            return NSLocalizedString("EditorMedia", comment: "Label for the media option in the editor tools")
+            return NSLocalizedString("EditorMedia", value: "Media", comment: "Label for the media option in the editor tools")
         case .drawing:
-            return NSLocalizedString("EditorDrawing", comment: "Label for the drawing option in the editor tools")
+            return NSLocalizedString("EditorDrawing", value: "Drawing", comment: "Label for the drawing option in the editor tools")
         case .cropRotate:
-            return NSLocalizedString("EditorCropRotate", comment: "Label for the crop rotate option in the editor tools")
+            return NSLocalizedString("EditorCropRotate", value: "Crop/Rotate", comment: "Label for the crop rotate option in the editor tools")
         }
     }
 }

--- a/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
+++ b/Classes/Editor/Menu/StyleMenu/StyleMenuView.swift
@@ -335,7 +335,7 @@ final class StyleMenuView: IgnoreTouchesView, StyleMenuCellDelegate, StyleMenuEx
         }
         
         let completion: (Bool) -> Void = { [weak self] _ in
-            self?.expandCell.changeLabel(to: NSLocalizedString("EditorMore", comment: "Label for the 'More' option in the editor tools"))
+            self?.expandCell.changeLabel(to: NSLocalizedString("EditorMore", value: "More", comment: "Label for the 'More' option in the editor tools"))
         }
         
         if animated {
@@ -353,7 +353,7 @@ final class StyleMenuView: IgnoreTouchesView, StyleMenuCellDelegate, StyleMenuEx
     /// - Parameter animated: whether to animate the transition or not.
     func expandCollection(animated: Bool = false) {
         state = .expanded
-        expandCell.changeLabel(to: NSLocalizedString("EditorClose", comment: "Label for the 'Close' option in the editor tools"))
+        expandCell.changeLabel(to: NSLocalizedString("EditorClose", value: "Close", comment: "Label for the 'Close' option in the editor tools"))
         stopTimer()
         
         let action: () -> Void = { [weak self] in

--- a/Classes/Editor/Shared/ColorSelector/ColorSelectorView.swift
+++ b/Classes/Editor/Shared/ColorSelector/ColorSelectorView.swift
@@ -201,7 +201,7 @@ final class ColorSelectorView: UIView {
         preferences.positioning.textVInset = Constants.tooltipVerticalTextInset
         preferences.positioning.textHInset = Constants.tooltipHorizontalTextInset
         
-        let text = NSLocalizedString("Drag to select color", comment: "Color selector tooltip for the Camera")
+        let text = NSLocalizedString("Drag to select color", value: "Drag to select color", comment: "Color selector tooltip for the Camera")
         tooltip = EasyTipView(text: text, preferences: preferences)
     }
     

--- a/Classes/MediaPicker/MediaPickerViewController.swift
+++ b/Classes/MediaPicker/MediaPickerViewController.swift
@@ -150,7 +150,7 @@ private extension KanvasMediaPickerViewController {
         }
         else if let image = image {
             guard canPick(image: image) else {
-                let message = NSLocalizedString("That's too big, bud.", comment: "That's too big, bud.")
+                let message = NSLocalizedString("That's too big, bud.", value: "That's too big, bud.", comment: "That's too big, bud.")
                 cannotPick(reason: message)
                 return
             }

--- a/Classes/ModeSelector/ModeSelectorAndShootView.swift
+++ b/Classes/ModeSelector/ModeSelectorAndShootView.swift
@@ -241,7 +241,7 @@ final class ModeSelectorAndShootView: IgnoreTouchesView, EasyTipViewDelegate {
         preferences.positioning.textHInset = ModeSelectorAndShootViewConstants.tooltipBubbleWidth
         preferences.positioning.textVInset = ModeSelectorAndShootViewConstants.tooltipBubbleHeight
         preferences.positioning.margin = ModeSelectorAndShootViewConstants.tooltipTopMargin
-        let text = NSLocalizedString("Tap to switch modes", comment: "Indicates to the user that they can tap a button to switch camera modes")
+        let text = NSLocalizedString("Tap to switch modes", value: "Tap to switch modes", comment: "Indicates to the user that they can tap a button to switch camera modes")
         
         return EasyTipView(text: text, preferences: preferences, delegate: self)
     }
@@ -258,7 +258,7 @@ final class ModeSelectorAndShootView: IgnoreTouchesView, EasyTipViewDelegate {
         preferences.positioning.textHInset = 18
         preferences.positioning.textVInset = 14
         preferences.positioning.margin = 4
-        let text = NSLocalizedString("Tap and hold to record", comment: "Indicates to the user that they can tap and hold to record")
+        let text = NSLocalizedString("Tap and hold to record", value: "Tap and hold to record", comment: "Indicates to the user that they can tap and hold to record")
         
         return EasyTipView(text: text, preferences: preferences, delegate: self)
     }

--- a/Classes/Preview/CameraPreviewViewController.swift
+++ b/Classes/Preview/CameraPreviewViewController.swift
@@ -325,13 +325,13 @@ extension CameraPreviewViewController: CameraPreviewViewDelegate {
                 }
                 else {
                     self.hideLoading()
-                    let alertController = UIAlertController(title: nil, message: NSLocalizedString("SomethingGoofedTitle", comment: "Alert controller message"), preferredStyle: .alert)
+                    let alertController = UIAlertController(title: nil, message: NSLocalizedString("SomethingGoofedTitle", value: "Something goofed.", comment: "Alert controller message"), preferredStyle: .alert)
                     
-                    let cancelButton = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel alert controller"), style: .cancel) { [weak self] _ in
+                    let cancelButton = UIAlertAction(title: NSLocalizedString("Cancel", value: "Cancel", comment: "Title for cancel button."), style: .cancel) { [weak self] _ in
                         self?.delegate?.didFinishExportingVideo(url: url)
                     }
                     
-                    let tryAgainButton = UIAlertAction(title: NSLocalizedString("Try again", comment: "Try creating final content again"), style: .default) { [weak self] _ in
+                    let tryAgainButton = UIAlertAction(title: NSLocalizedString("Try again", value: "Try again", comment: "Try again"), style: .default) { [weak self] _ in
                         self?.showLoading()
                         self?.createFinalContent()
                     }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - iOSSnapshotTestCase/Core (8.0.0)
   - iOSSnapshotTestCase/SwiftSupport (8.0.0):
     - iOSSnapshotTestCase/Core
-  - Kanvas (1.5.1):
+  - Kanvas (1.5.2):
     - CropViewController
 
 DEPENDENCIES:
@@ -25,7 +25,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CropViewController: 58fb440f30dac788b129d2a1f24cffdcb102669c
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
-  Kanvas: c2b047c19d26ff60ee6db30ed824551494b4eba3
+  Kanvas: 5203490649cb4c2ea6a796cf89b73e87c57ddda1
 
 PODFILE CHECKSUM: 7f87a0c75f7e07c253792681a758e25d03b1f121
 

--- a/Kanvas.podspec
+++ b/Kanvas.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = 'Kanvas'
-  spec.version      = '1.5.1'
+  spec.version      = '1.5.2'
   spec.summary      = 'A custom camera built for iOS.'
   spec.homepage     = 'https://github.com/tumblr/kanvas-ios'
   spec.license      = 'MPLv2'


### PR DESCRIPTION
Updates `NSLocalizedStrings` to explicitly define a `value`.

This will make kanvas compatible with genstrings tool.
genstrings uses the value defined in the localized string to generate the key-value pair in the Localizable.strings file.

key - key
value - value
comment - comment for translators

Example:
```
NSLocalizedString("TryAgainKey", value: "Try again", comment: "Title for a button that allows the user to retry an action.")

/* Title for a button that allows the user to retry an action.*/
"TryAgainKey" = "Try again";

```