### PR TITLE
AINFRA-283 - Set `queue: mac` explicitly in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
   IMAGE_ID: xcode-15.0.1
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ env:
 
 common_params:
   - &common_plugins
-    - automattic/bash-cache#5.3.1
+    - automattic/a8c-ci-toolkit#5.3.1
 
 steps:
   #################
@@ -29,12 +29,7 @@ steps:
   - label: "Validate Podspec"
     key: validate
     command: |
-      # validate_podspec
-      echo '+++ ⚠️ validate_podspec was bypassed ⚠️'
-      # post a message in the logs
-      cat .buildkite/validate_podspec_annotation.md
-      # and also as an annotation
-      cat .buildkite/validate_podspec_annotation.md | buildkite-agent annotate --style 'warning'
+      validate_podspec --patch-cocoapods
     plugins: *common_plugins
     agents:
       queue: upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ env:
 
 common_params:
   - &common_plugins
-    - automattic/bash-cache#2.2.0
+    - automattic/bash-cache#5.3.1
 
 steps:
   #################

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+env:
+  IMAGE_ID: xcode-15.0.1
+
 common_params:
   - &common_plugins
     - automattic/bash-cache#2.2.0
-  - &common_env
-    IMAGE_ID: xcode-15.0.1
 
 steps:
   #################
@@ -12,7 +16,6 @@ steps:
     key: test
     command: |
       build_and_test_pod
-    env: *common_env
     plugins: *common_plugins
     artifact_paths:
       - "artifacts/**/*"
@@ -29,7 +32,6 @@ steps:
       cat .buildkite/validate_podspec_annotation.md
       # and also as an annotation
       cat .buildkite/validate_podspec_annotation.md | buildkite-agent annotate --style 'warning'
-    env: *common_env
     plugins: *common_plugins
     agents:
       queue: upload
@@ -41,7 +43,6 @@ steps:
     key: lint
     command: |
       lint_pod
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -49,7 +50,6 @@ steps:
   #################
   - label: "⬆️ Publish Pod"
     command: .buildkite/commands/publish-pod.sh
-    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,8 +31,6 @@ steps:
     command: |
       validate_podspec --patch-cocoapods
     plugins: *common_plugins
-    agents:
-      queue: upload
 
   #################
   # Lint

--- a/.buildkite/validate_podspec_annotation.md
+++ b/.buildkite/validate_podspec_annotation.md
@@ -1,8 +1,0 @@
-**`validate_podspec` was bypassed!**
-
-As of Xcode 14.3, libraries with deployment target below iOS 11 (iOS 12 in Xcode 15) fail to build out of the box.
-The reason is a missing file, `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/arc/libarclite_iphonesimulator.a`, more info [here](https://stackoverflow.com/questions/75574268/missing-file-libarclite-iphoneos-a-xcode-14-3).
-
-Client apps can work around this with a post install hook that updates the dependency deployment target, but libraries do not have this option.
-
-In the interest of using up to date CI (i.e. not waste time downloading old images) we bypass validation until CocoaPods fixes the root issue.


### PR DESCRIPTION
This will allow adopting an improved default pipeline upload step on the CI infrastructure side of the setup. It also makes it clear what queue is in use just by looking at the pipeline file.

Notice it does not introduce the standard `shared-pipeline-vars` file because to use that we first need the default pipeline upload step in the IaC configuration.

See https://linear.app/a8c/issue/AINFRA-283